### PR TITLE
Simplify the encoding of size

### DIFF
--- a/src/connections/stream_api.rs
+++ b/src/connections/stream_api.rs
@@ -278,7 +278,7 @@ impl<State> ConnectedStreamApi<State> {
     ///
     pub async fn send_raw(&mut self, data: EncodedToRadioPacket) -> Result<(), Error> {
         let channel = self.write_input_tx.clone();
-        let data_with_header = utils::format_data_packet(data);
+        let data_with_header = utils::format_data_packet(data)?;
 
         channel
             .send(data_with_header)

--- a/src/errors_internal.rs
+++ b/src/errors_internal.rs
@@ -32,6 +32,10 @@ pub enum Error {
         description: String,
     },
 
+    /// An error indicating that too much data is being sent.
+    #[error("Trying to send too much data")]
+    InvalidaDataSize { data_length: usize },
+
     /// An error indicating that the method failed to remove a packet header from a packet buffer
     /// due to the packet buffer being too small to contain a header.
     #[error("Failed to remove packet header from packet buffer due to insufficient data length: {packet}")]

--- a/src/utils_internal.rs
+++ b/src/utils_internal.rs
@@ -270,10 +270,10 @@ where
 ///
 pub fn format_data_packet(packet: EncodedToRadioPacket) -> EncodedToRadioPacketWithHeader {
     let data = packet.data();
-    let (msb, _) = data.len().overflowing_shr(8);
-    let lsb = (data.len() & 0xff) as u8;
-
-    let magic_buffer = [0x94, 0xc3, msb as u8, lsb];
+    // Note that if data.len() has more than 2 bytes, there's no way to signal an error from this
+    // function.
+    let [lsb, msb, ..] = data.len().to_le_bytes();
+    let magic_buffer = [0x94, 0xc3, msb, lsb];
 
     [&magic_buffer, data].concat().into()
 }


### PR DESCRIPTION
The `to_le_bytes/from_le_bytes` functions can be used to convert between
integers and their byte representation.
