### PR TITLE
Improve error handling

### DIFF
--- a/src/errors_internal.rs
+++ b/src/errors_internal.rs
@@ -86,6 +86,9 @@ pub enum InternalChannelError {
     /// An error indicating that the library failed to write to an internal data channel.
     #[error(transparent)]
     IncomingStreamDataWriteError(#[from] tokio::sync::mpsc::error::SendError<IncomingStreamData>),
+
+    #[error("Channel unexpectedly closed")]
+    ChannelClosedEarly,
 }
 
 mod test {


### PR DESCRIPTION
Improve error handling

Propagate errors in the handlers. The errors are now caught in the `disconnect` function but we should work towards notifying the user even sooner.

This is an improvement though, as previously the user hasn't been notified at all.