### PR TITLE
Connection reliability fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,5 @@ serde_json = { version = "1.0", optional = true }
 thiserror = "1.0.48"
 uuid = "1.6.1"
 btleplug = "0.11.5"
+fern = { version = "0.6.2", features = ["colored"] }
+humantime = "2.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,5 +54,7 @@ serde_json = { version = "1.0", optional = true }
 thiserror = "1.0.48"
 uuid = "1.6.1"
 btleplug = "0.11.5"
+
+[dev-dependencies]
 fern = { version = "0.6.2", features = ["colored"] }
 humantime = "2.1.0"

--- a/examples/basic_serial.rs
+++ b/examples/basic_serial.rs
@@ -9,7 +9,8 @@ use std::time::SystemTime;
 use meshtastic::api::StreamApi;
 use meshtastic::utils;
 
-/// Set up the logger to output to the console and to a file.
+/// Set up the logger to output to stdout  
+/// **Note:** the invokation of this function is commented out in main by default.
 fn setup_logger() -> Result<(), fern::InitError> {
     fern::Dispatch::new()
         .format(|out, message, record| {
@@ -30,7 +31,8 @@ fn setup_logger() -> Result<(), fern::InitError> {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    setup_logger()?;
+    // Uncomment this to enable logging
+    // setup_logger()?;
 
     let stream_api = StreamApi::new();
 
@@ -54,8 +56,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // This loop can be broken with ctrl+c, or by disconnecting
     // the attached serial port.
-    while let Some(_decoded) = decoded_listener.recv().await {
-        // println!("Received: {:?}", decoded);
+    while let Some(decoded) = decoded_listener.recv().await {
+        println!("Received: {:?}", decoded);
     }
 
     // Note that in this specific example, this will only be called when

--- a/examples/basic_tcp.rs
+++ b/examples/basic_tcp.rs
@@ -9,7 +9,8 @@ use std::time::SystemTime;
 use meshtastic::api::StreamApi;
 use meshtastic::utils;
 
-/// Set up the logger to output to the console and to a file.
+/// Set up the logger to output to stdout  
+/// **Note:** the invokation of this function is commented out in main by default.
 fn setup_logger() -> Result<(), fern::InitError> {
     fern::Dispatch::new()
         .format(|out, message, record| {
@@ -30,7 +31,8 @@ fn setup_logger() -> Result<(), fern::InitError> {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    setup_logger()?;
+    // Uncomment this to enable logging
+    // setup_logger()?;
 
     let stream_api = StreamApi::new();
 
@@ -51,8 +53,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let stream_api = stream_api.configure(config_id).await?;
 
     // This loop can be broken with ctrl+c, or by unpowering the radio.
-    while let Some(_decoded) = decoded_listener.recv().await {
-        // println!("Received: {:?}", decoded);
+    while let Some(decoded) = decoded_listener.recv().await {
+        println!("Received: {:?}", decoded);
     }
 
     // Note that in this specific example, this will only be called when

--- a/src/connections/handlers.rs
+++ b/src/connections/handlers.rs
@@ -16,6 +16,10 @@ use crate::connections::stream_buffer::StreamBuffer;
 
 use super::wrappers::encoded_data::IncomingStreamData;
 
+/// Interval for sending heartbeat packets to the radio (in seconds).
+/// Needs to be less than this: https://github.com/meshtastic/firmware/blob/eb372c190ec82366998c867acc609a418130d842/src/SerialConsole.cpp#L8
+pub const SERIAL_HEARTBEAT_INTERVAL: u64 = 5 * 60; // 5 minutes
+
 pub fn spawn_read_handler<R>(
     cancellation_token: CancellationToken,
     read_stream: R,
@@ -212,7 +216,7 @@ where
     debug!("Started heartbeat handler");
 
     loop {
-        tokio::time::sleep(std::time::Duration::from_secs(5 * 60)).await;
+        tokio::time::sleep(std::time::Duration::from_secs(SERIAL_HEARTBEAT_INTERVAL)).await;
 
         let mut write_stream = write_stream.lock().await;
 
@@ -235,6 +239,8 @@ where
                 },
             ));
         }
+
+        log::info!("Sent heartbeat packet");
     }
 
     // debug!("Heartbeat handler finished");

--- a/src/connections/handlers.rs
+++ b/src/connections/handlers.rs
@@ -220,7 +220,7 @@ where
 
         let mut write_stream = write_stream.lock().await;
 
-        let heartbeat_packet = protobufs::ToRadio::default();
+        let heartbeat_packet = protobufs::Heartbeat::default();
 
         let mut buffer = Vec::new();
         match heartbeat_packet.encode(&mut buffer) {

--- a/src/connections/handlers.rs
+++ b/src/connections/handlers.rs
@@ -18,7 +18,7 @@ use super::wrappers::encoded_data::IncomingStreamData;
 
 /// Interval for sending heartbeat packets to the radio (in seconds).
 /// Needs to be less than this: https://github.com/meshtastic/firmware/blob/eb372c190ec82366998c867acc609a418130d842/src/SerialConsole.cpp#L8
-pub const SERIAL_HEARTBEAT_INTERVAL: u64 = 5 * 60; // 5 minutes
+pub const CLIENT_HEARTBEAT_INTERVAL: u64 = 5 * 60; // 5 minutes
 
 pub fn spawn_read_handler<R>(
     cancellation_token: CancellationToken,
@@ -216,7 +216,7 @@ where
     debug!("Started heartbeat handler");
 
     loop {
-        tokio::time::sleep(std::time::Duration::from_secs(SERIAL_HEARTBEAT_INTERVAL)).await;
+        tokio::time::sleep(std::time::Duration::from_secs(CLIENT_HEARTBEAT_INTERVAL)).await;
 
         let mut write_stream = write_stream.lock().await;
 

--- a/src/connections/stream_api.rs
+++ b/src/connections/stream_api.rs
@@ -198,6 +198,8 @@ impl<State> ConnectedStreamApi<State> {
             priority: 0,  // * not transmitted
             rx_rssi: 0,   // * not transmitted
             delayed: 0,   // * not transmitted
+            hop_start: 0, // * set on device
+            via_mqtt: false,
             from: own_node_id.id(),
             to: packet_destination.id(),
             id: generate_rand_id(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@ pub mod errors {
 /// The `PacketReceiver` type defines the type of the tokio channel that is used to receive decoded packets from the radio.
 /// This is intended to simplify the complexity of the underlying channel type.
 pub mod packet {
+    pub use crate::connections::handlers::CLIENT_HEARTBEAT_INTERVAL;
     pub use crate::connections::PacketDestination;
     pub use crate::connections::PacketRouter;
 


### PR DESCRIPTION
This PR makes the following changes:
- Adds logging samples to serial and TCP examples
- Adds periodic transmission of a new `Heartbeat` packet every 5 minutes
- Fixes bug in stream processing where framing index was calculated too late
- Fixes bug in stream processing where framing index isn't recalculated after clearing buffer, leading to out of bounds failures when trying to reference framing bytes
- Adds test case to validate repeat buffer clearing functionality