### PR TITLE
push bluetooth-le behind feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ default = ["serde"]
 
 serde = ["dep:serde", "dep:serde_json"]
 ts-gen = ["serde", "dep:specta"]
+bluetooth-le = ["dep:uuid","dep:btleplug"]
 
 [[example]]
 name = "basic_serial"
@@ -52,8 +53,8 @@ specta = { git = "https://github.com/ajmcquilkin/specta.git", rev = "6a8731d", o
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 thiserror = "1.0.48"
-uuid = "1.6.1"
-btleplug = "0.11.5"
+uuid = { version = "1.6.1", optional = true }
+btleplug = { version = "0.11.5", optional = true }
 
 [dev-dependencies]
 fern = { version = "0.6.2", features = ["colored"] }

--- a/src/errors_internal.rs
+++ b/src/errors_internal.rs
@@ -93,6 +93,7 @@ pub enum InternalChannelError {
 
 #[derive(Error, Debug)]
 #[error("Bluetooth low energy connection error")]
+#[cfg(feature = "bluetooth-le")]
 pub struct BleConnectionError();
 
 mod test {

--- a/src/utils_internal.rs
+++ b/src/utils_internal.rs
@@ -1,9 +1,15 @@
-use crate::errors_internal::{BleConnectionError, Error};
+use crate::errors_internal::Error;
+#[cfg(feature = "bluetooth-le")]
+use crate::errors_internal::BleConnectionError;
+#[cfg(feature = "bluetooth-le")]
 use btleplug::api::{Central, Manager as _, Peripheral as _, ScanFilter};
+#[cfg(feature = "bluetooth-le")]
 use btleplug::platform::{Adapter, Manager, Peripheral};
+#[cfg(feature = "bluetooth-le")]
 use log::error;
 use std::time::Duration;
 use std::time::UNIX_EPOCH;
+#[cfg(feature = "bluetooth-le")]
 use uuid::Uuid;
 
 use rand::{distributions::Standard, prelude::Distribution, Rng};
@@ -198,8 +204,11 @@ pub async fn build_tcp_stream(
     Ok(StreamHandle::from_stream(stream))
 }
 
+
+#[cfg(feature = "bluetooth-le")]
 const MSH_SERVICE: Uuid = Uuid::from_u128(0x6ba1b218_15a8_461f_9fa8_5dcae273eafd);
 
+#[cfg(feature = "bluetooth-le")]
 async fn scan_peripherals(adapter: &Adapter) -> Result<Vec<Peripheral>, btleplug::Error> {
     adapter
         .start_scan(ScanFilter {
@@ -211,6 +220,7 @@ async fn scan_peripherals(adapter: &Adapter) -> Result<Vec<Peripheral>, btleplug
 
 /// Finds a BLE radio matching a given name and running meshtastic.
 /// It searches for the 'MSH_SERVICE' running on the device.
+#[cfg(feature = "bluetooth-le")]
 async fn find_ble_radio(name: String) -> Result<Peripheral, Error> {
     //TODO: support searching both by a name and by a MAC address
     let scan_error_fn = |e: btleplug::Error| Error::StreamBuildError {


### PR DESCRIPTION
The introduction of `btleplug` module includes the requirement of libdbus-1-dev which is not available for all cross-compilation platforms.  

This PR ensures that the BLE code is behind a feature flag so that people who want said functionality, can use it.

This PR also updates the protobufs to the latest version in the repository.  I can rebase without this, if necessary.

(cc @lukipuki )