### PR TITLE
Abort read handler when read stream returns EOF

### DIFF
--- a/src/connections/handlers.rs
+++ b/src/connections/handlers.rs
@@ -2,7 +2,7 @@ use crate::errors_internal::{Error, InternalChannelError, InternalStreamError};
 use crate::protobufs;
 use crate::types::EncodedToRadioPacketWithHeader;
 use crate::utils::format_data_packet;
-use log::{debug, error, trace};
+use log::{debug, error, trace, warn};
 use prost::Message;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::spawn;
@@ -57,7 +57,12 @@ where
     loop {
         let mut buffer = [0u8; 1024];
         match read_stream.read(&mut buffer).await {
-            Ok(0) => continue,
+            Ok(0) => {
+                warn!("read_stream has reached EOF");
+                return Err(Error::InternalStreamError(
+                    InternalStreamError::Eof
+                ))
+            },
             Ok(n) => {
                 trace!("Read {} bytes from stream", n);
                 let data: IncomingStreamData = buffer[..n].to_vec().into();

--- a/src/errors_internal.rs
+++ b/src/errors_internal.rs
@@ -67,6 +67,10 @@ pub enum InternalStreamError {
     StreamWriteError {
         source: Box<dyn std::error::Error + Send + Sync + 'static>,
     },
+
+    /// An error indicating the stream has reached its "end of file" and will likely no longer be able to produce bytes.
+    #[error("Stream has reached EOF")]
+    Eof
 }
 
 /// An enum that defines the possible internal errors that can occur within the library when handling data channels.


### PR DESCRIPTION
If read_stream.read returns 0 bytes read (indicating EOF), return an error to terminate message processing. This prevents the read handler from entering into a tight loop where 0 bytes are read repeatedly.

Currently, if the radio is disconnected (eg: USB unplugged, network error, radio reboot) the read handler spikes cpu usage to 100% on a single core.

Technically, the AsyncReadExt contract does not guarantee that data is never returned after a zero-byte read; however, in practice for the concrete implementations in this library, this is the case.

An alternative implementation could be introducing a short delay after reading 0 bytes, then relying on the heartbeat to detect a disconnected radio. However, the default heartbeat of 5 minutes means there could potentially be a long delay before a disconnect is noticed. This is especially undesirable when using the TCP connection as simply reconnecting to the radio will likely clear the error condition.

Fixes #14 