### PR TITLE
Require ts-gen feature for an example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ name = "message_filtering"
 
 [[example]]
 name = "generate_typescript_types"
+required-features = ["ts-gen"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
`generate_typescript_types` requires `ts-gen` to be built