### PR TITLE
Update to meshtatic/protobufs v2.4.3

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,16 +1,8 @@
-fn main() -> std::io::Result<()> {
-    #[cfg(feature = "gen")]
-    {
-        generate_protobufs()
-    }
-    #[cfg(not(feature = "gen"))]
-    {
-        Ok(())
-    }
-}
+#[cfg(not(feature = "gen"))]
+fn main() {}
 
 #[cfg(feature = "gen")]
-fn generate_protobufs() -> std::io::Result<()> {
+fn main() -> std::io::Result<()> {
     let protobufs_dir = "src/protobufs/";
     let gen_dir = "src/generated/";
 


### PR DESCRIPTION
Make protobufs version more up to date. v2.5 has new encryption fields which will require code changes and could be addressed in separate PR later.