### PR TITLE
Use inspect_err where appropriate

### DIFF
--- a/src/connections/handlers.rs
+++ b/src/connections/handlers.rs
@@ -66,10 +66,10 @@ where
                 let data: IncomingStreamData = buffer[..n].to_vec().into();
                 trace!("Read data: {:?}", data);
 
-                if let Err(e) = read_output_tx.send(data) {
-                    error!("Failed to send data through channel");
-                    return Err(Error::InternalChannelError(e.into()));
-                }
+                read_output_tx
+                    .send(data)
+                    .inspect_err(|_| error!("Failed to send data through channel"))
+                    .map_err(|e| InternalChannelError::from(e))?
             }
 
             // TODO check if port has fatally errored, and if so, tell UI
@@ -106,10 +106,7 @@ where
                 Ok(())
             }
             write_result = handle => {
-                if let Err(e) = &write_result {
-                    error!("Write handler unexpectedly terminated {e:?}");
-                }
-                write_result
+                write_result.inspect_err(|e| error!("Write handler unexpectedly terminated {e:?}"))
             }
         }
     })
@@ -128,14 +125,11 @@ where
     while let Some(message) = write_input_rx.recv().await {
         trace!("Writing packet data: {:?}", message);
 
-        if let Err(e) = write_stream.write(message.data()).await {
-            error!("Error writing to stream: {:?}", e);
-            return Err(Error::InternalStreamError(
-                InternalStreamError::StreamWriteError {
-                    source: Box::new(e),
-                },
-            ));
-        }
+        write_stream
+            .write(message.data())
+            .await
+            .inspect_err(|e| error!("Error writing to stream: {:?}", e))
+            .map_err(|e| InternalStreamError::write_error(e))?;
     }
 
     debug!("Write handler finished");
@@ -192,10 +186,9 @@ pub fn spawn_heartbeat_handler(
                 Ok(())
             }
             write_result = handle => {
-                if let Err(e) = &write_result {
-                    error!("Heartbeat handler unexpectedly terminated {e:?}");
-                }
-                write_result
+                write_result.inspect_err(|e|
+                    error!("Heartbeat handler unexpectedly terminated {e:?}")
+                )
             }
         }
     })
@@ -235,14 +228,10 @@ async fn start_heartbeat_handler(
 
         trace!("Sending heartbeat packet");
 
-        if let Err(e) = write_input_tx.send(packet_with_header) {
-            error!("Error writing heartbeat packet to stream: {:?}", e);
-            return Err(Error::InternalStreamError(
-                InternalStreamError::StreamWriteError {
-                    source: Box::new(e),
-                },
-            ));
-        }
+        write_input_tx
+            .send(packet_with_header)
+            .inspect_err(|e| error!("Error writing heartbeat packet to stream: {:?}", e))
+            .map_err(|e| InternalStreamError::write_error(e))?;
 
         log::info!("Sent heartbeat packet");
     }

--- a/src/connections/handlers.rs
+++ b/src/connections/handlers.rs
@@ -69,7 +69,7 @@ where
                 read_output_tx
                     .send(data)
                     .inspect_err(|_| error!("Failed to send data through channel"))
-                    .map_err(|e| InternalChannelError::from(e))?
+                    .map_err(InternalChannelError::from)?
             }
 
             // TODO check if port has fatally errored, and if so, tell UI
@@ -129,7 +129,7 @@ where
             .write(message.data())
             .await
             .inspect_err(|e| error!("Error writing to stream: {:?}", e))
-            .map_err(|e| InternalStreamError::write_error(e))?;
+            .map_err(InternalStreamError::write_error)?;
     }
 
     debug!("Write handler finished");
@@ -231,7 +231,7 @@ async fn start_heartbeat_handler(
         write_input_tx
             .send(packet_with_header)
             .inspect_err(|e| error!("Error writing heartbeat packet to stream: {:?}", e))
-            .map_err(|e| InternalStreamError::write_error(e))?;
+            .map_err(InternalStreamError::write_error)?;
 
         log::info!("Sent heartbeat packet");
     }

--- a/src/errors_internal.rs
+++ b/src/errors_internal.rs
@@ -78,6 +78,14 @@ pub enum InternalStreamError {
     ConnectionLost,
 }
 
+impl InternalStreamError {
+    pub fn write_error(err: impl std::error::Error + Send + Sync + 'static) -> Self {
+        Self::StreamWriteError {
+            source: Box::new(err),
+        }
+    }
+}
+
 /// An enum that defines the possible internal errors that can occur within the library when handling data channels.
 #[allow(clippy::enum_variant_names)]
 #[derive(Error, Debug)]


### PR DESCRIPTION
**Summary**
There's `Result::inspect_err` since Rust 1.76, it allows for more readable error inspection.

I've also added `InternalStreamError::write_error` function which reduces boiler-plate.

**Related Issues**
Minor cleanup

**Checklist**
- [x] Tests pass locally
- [x] Documentation updated if needed
