### PR TITLE
chore: Fix compiler warnings in `examples/`

### DIFF
--- a/examples/basic_serial.rs
+++ b/examples/basic_serial.rs
@@ -11,6 +11,7 @@ use meshtastic::utils;
 
 /// Set up the logger to output to stdout  
 /// **Note:** the invocation of this function is commented out in main by default.
+#[allow(dead_code)]
 fn setup_logger() -> Result<(), fern::InitError> {
     fern::Dispatch::new()
         .format(|out, message, record| {

--- a/examples/basic_tcp.rs
+++ b/examples/basic_tcp.rs
@@ -11,6 +11,7 @@ use meshtastic::utils;
 
 /// Set up the logger to output to stdout  
 /// **Note:** the invocation of this function is commented out in main by default.
+#[allow(dead_code)]
 fn setup_logger() -> Result<(), fern::InitError> {
     fern::Dispatch::new()
         .format(|out, message, record| {


### PR DESCRIPTION
**Summary**
Silence the dead code compiler warnings. Alternatively we could enable them dynamically are run with a `--features log` flag, which I think is actually a better solution, but it's also a bit more heavy handed.

I've never contributed to this repo before so this is a much less opinionated fix.

**Checklist**
- [x] Tests pass locally
- [x] Documentation updated if needed
