### PR TITLE
Switch to upstream specta

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default = ["serde"]
 gen = ["dep:prost-build", "dep:protoc-bin-vendored", "dep:walkdir"]
 
 serde = ["dep:serde", "dep:serde_json"]
-ts-gen = ["gen", "serde", "dep:specta", "dep:specta-typescript"]
+ts-gen = ["serde", "dep:specta", "dep:specta-typescript"]
 bluetooth-le = ["dep:uuid", "dep:btleplug", "dep:futures", "dep:bluez-async"]
 
 [lints.rust]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default = ["serde"]
 gen = ["dep:prost-build", "dep:protoc-bin-vendored", "dep:walkdir"]
 
 serde = ["dep:serde", "dep:serde_json"]
-ts-gen = ["gen", "serde", "dep:specta"]
+ts-gen = ["gen", "serde", "dep:specta", "dep:specta-typescript"]
 bluetooth-le = ["dep:uuid", "dep:btleplug", "dep:futures", "dep:bluez-async"]
 
 [lints.rust]
@@ -57,7 +57,12 @@ tokio-util = "0.7.13"
 prost = "0.14"
 log = "0.4.25"
 
-specta = { git = "https://github.com/ajmcquilkin/specta.git", rev = "6a8731d", optional = true, features = ["chrono"], version = "=1.0.3" }
+specta = { git = "https://github.com/specta-rs/specta.git", rev = "b596ef0", optional = true, features = [
+    "derive",
+    "export",
+    "chrono",
+] }
+specta-typescript = { git = "https://github.com/specta-rs/specta.git", rev = "b596ef0", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 thiserror = "2.0.11"

--- a/examples/generate_typescript_types.rs
+++ b/examples/generate_typescript_types.rs
@@ -1,29 +1,17 @@
-//! This example connects to a radio via serial, and demonstrates how to
-//! configure handlers for different types of decoded radio packets.
-//! https://meshtastic.org/docs/supported-hardware
+//! This example exports meshtastic/protobufs Rust types into TypeScript
 //!
 //! Run this example with the command `cargo run --example generate_typescript_types --features "ts-gen"`
 extern crate meshtastic;
 
-use meshtastic::ts::specta::{
-    export::ts_with_cfg,
-    ts::{BigIntExportBehavior, ExportConfiguration, ModuleExportBehavior, TsExportError},
-};
+use specta_typescript::Typescript;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Exports relative to the root workspace directory
-    export_ts_types("./examples/bindings.ts")?;
+    Typescript::default()
+        .bigint(specta_typescript::BigIntExportBehavior::String)
+        .format(specta_typescript::Format::ModulePrefixedName)
+        .export_to("./examples/bindings.ts", &specta::export())?;
 
     Ok(())
-}
-
-fn export_ts_types(file_path: &str) -> Result<(), TsExportError> {
-    // Sets up a default configuration for exporting typescript types
-    let ts_export_config = ExportConfiguration::default()
-        .bigint(BigIntExportBehavior::String)
-        .modules(ModuleExportBehavior::Enabled);
-
-    // Use Specta helper function to export typescript types
-    ts_with_cfg(file_path, &ts_export_config)
 }


### PR DESCRIPTION
Since https://github.com/specta-rs/specta/issues/62 is resolved now we could switch to the upstream.
Marking it as a draft since proper release of specta crate is yet to come.
