### PR TITLE
Add `warn(missing_docs)` lint and fix all instances of it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ serde = ["dep:serde", "dep:serde_json"]
 ts-gen = ["gen", "serde", "dep:specta"]
 bluetooth-le = ["dep:uuid", "dep:btleplug", "dep:futures"]
 
+[lints.rust]
+missing_docs = "warn"
+
 [[example]]
 name = "basic_serial"
 

--- a/build.rs
+++ b/build.rs
@@ -41,7 +41,7 @@ fn main() -> std::io::Result<()> {
         protos.push(path.to_owned());
     }
 
-    protos.sort_by(|a, b| a.cmp(b));
+    protos.sort();
 
     let mut config = prost_build::Config::new();
 

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,5 @@
+//! The `build.rs` script for this crate.
+
 #[cfg(not(feature = "gen"))]
 fn main() {}
 

--- a/build.rs
+++ b/build.rs
@@ -64,10 +64,10 @@ fn main() -> std::io::Result<()> {
     #[cfg(feature = "serde")]
     {
         config.type_attribute(".", "#[serde(rename_all = \"camelCase\")]");
-        config.type_attribute(".", "#[allow(clippy::doc_lazy_continuation)]");
-        config.type_attribute(".", "#[allow(clippy::empty_docs)]");
     }
 
+    config.type_attribute(".", "#[allow(clippy::doc_lazy_continuation)]");
+    config.type_attribute(".", "#[allow(clippy::empty_docs)]");
     config.type_attribute(".", "#[allow(missing_docs)]");
     config.type_attribute(".", "#[allow(clippy::doc_overindented_list_items)]");
 

--- a/build.rs
+++ b/build.rs
@@ -68,6 +68,9 @@ fn main() -> std::io::Result<()> {
         config.type_attribute(".", "#[allow(clippy::empty_docs)]");
     }
 
+    config.type_attribute(".", "#[allow(missing_docs)]");
+    config.type_attribute(".", "#[allow(clippy::doc_overindented_list_items)]");
+
     config.out_dir(gen_dir);
     config.compile_protos(&protos, &[protobufs_dir])
 }

--- a/examples/basic_serial.rs
+++ b/examples/basic_serial.rs
@@ -1,6 +1,6 @@
-/// This example connects to a radio via serial, and prints out all received packets.
-/// This example requires a powered and flashed Meshtastic radio.
-/// https://meshtastic.org/docs/supported-hardware
+//! This example connects to a radio via serial, and prints out all received packets.
+//! This example requires a powered and flashed Meshtastic radio.
+//! https://meshtastic.org/docs/supported-hardware
 extern crate meshtastic;
 
 use std::io::{self, BufRead};

--- a/examples/basic_tcp.rs
+++ b/examples/basic_tcp.rs
@@ -1,6 +1,6 @@
-/// This example connects to a TCP port on the radio, and prints out all received packets.
-/// This can be used with a simulated radio via the Meshtastic Docker firmware image.
-/// https://meshtastic.org/docs/software/linux-native#usage-with-docker
+//! This example connects to a TCP port on the radio, and prints out all received packets.
+//! This can be used with a simulated radio via the Meshtastic Docker firmware image.
+//! https://meshtastic.org/docs/software/linux-native#usage-with-docker
 extern crate meshtastic;
 
 use std::io::{self, BufRead};

--- a/examples/generate_typescript_types.rs
+++ b/examples/generate_typescript_types.rs
@@ -1,8 +1,8 @@
-/// This example connects to a radio via serial, and demonstrates how to
-/// configure handlers for different types of decoded radio packets.
-/// https://meshtastic.org/docs/supported-hardware
-///
-/// Run this example with the command `cargo run --example generate_typescript_types --features "ts-gen"`
+//! This example connects to a radio via serial, and demonstrates how to
+//! configure handlers for different types of decoded radio packets.
+//! https://meshtastic.org/docs/supported-hardware
+//!
+//! Run this example with the command `cargo run --example generate_typescript_types --features "ts-gen"`
 extern crate meshtastic;
 
 use meshtastic::ts::specta::{

--- a/examples/message_filtering.rs
+++ b/examples/message_filtering.rs
@@ -1,6 +1,6 @@
-/// This example connects to a radio via serial, and demonstrates how to
-/// configure handlers for different types of decoded radio packets.
-/// https://meshtastic.org/docs/supported-hardware
+//! This example connects to a radio via serial, and demonstrates how to
+//! configure handlers for different types of decoded radio packets.
+//! https://meshtastic.org/docs/supported-hardware
 extern crate meshtastic;
 
 use std::io::{self, BufRead};

--- a/src/connections/handlers.rs
+++ b/src/connections/handlers.rs
@@ -143,6 +143,7 @@ where
     Ok(())
 }
 
+/// Spawns a new handler for processing incoming packets.
 pub fn spawn_processing_handler(
     cancellation_token: CancellationToken,
     read_output_rx: UnboundedReceiver<IncomingStreamData>,

--- a/src/connections/mod.rs
+++ b/src/connections/mod.rs
@@ -27,9 +27,13 @@ pub mod wrappers;
 /// The default value for this enum is `Broadcast`.
 #[derive(Clone, Copy, Debug, Default)]
 pub enum PacketDestination {
+    /// A packet that should be handled by the connected node.
     Local,
+    /// A packet that should be broadcast to all nodes in the mesh.
     #[default]
     Broadcast,
+    /// A packet that should be sent to a specific node in the mesh,
+    /// specified by the passed `u32` id.
     Node(NodeId),
 }
 

--- a/src/connections/stream_api.rs
+++ b/src/connections/stream_api.rs
@@ -84,11 +84,23 @@ pub struct ConnectedStreamApi<State = state::Configured> {
 /// A struct that provides a reference to an underlying stream for reading/writing data and
 /// potentially an accompanying join handle that processes data on the other side of the stream.
 pub struct StreamHandle<T: AsyncReadExt + AsyncWriteExt + Send> {
+    /// The underlying stream.
     pub stream: T,
+    /// An optional join handle that processes data on the other side of the stream.
     pub join_handle: Option<JoinHandle<Result<(), Error>>>,
 }
 
 impl<T: AsyncReadExt + AsyncWriteExt + Send> StreamHandle<T> {
+    /// A method to create a new `StreamHandle` from a provided stream. The resulting [`StreamHandle`]
+    /// will have no join handle.
+    ///
+    /// # Arguments
+    ///
+    /// * `stream` - A generic stream that will be used as the underlying stream for the `StreamHandle`.
+    ///
+    /// # Returns
+    ///
+    /// Returns a new `StreamHandle` instance with the provided stream as the underlying stream.
     pub fn from_stream(stream: T) -> Self {
         Self {
             stream,

--- a/src/errors_internal.rs
+++ b/src/errors_internal.rs
@@ -41,7 +41,10 @@ pub enum Error {
     /// An error indicating that too much data is being sent.
     /// NOTE: This error name is misspelled and should be treated as if it is `InvalidDataSize`.
     #[error("Trying to send too much data")]
-    InvalidaDataSize { data_length: usize },
+    #[deprecated(
+        since = "0.1.6",
+        note = "This error type is no longer used. It is also misspelled in the meshtastic crate."
+    )]
     InvalidaDataSize {
         /// The length of the data of invalid size.
         data_length: usize,

--- a/src/errors_internal.rs
+++ b/src/errors_internal.rs
@@ -9,7 +9,10 @@ use crate::connections::wrappers::encoded_data::{
 pub enum Error {
     /// An error indicating that the user has entered a channel outside of the range of valid channels [0..7].
     #[error("Invalid channel {channel} entered. Valid channels are in the range [0..7]")]
-    InvalidChannelIndex { channel: u32 },
+    InvalidChannelIndex {
+        /// The invalid channel index that was entered.
+        channel: u32,
+    },
 
     /// An error indicating that the library failed to encode a protocol buffer message.
     #[error(transparent)]
@@ -22,13 +25,16 @@ pub enum Error {
     /// An error indicating that a struct implementing the `PacketRouter` trait failed to handle a packet.
     #[error("Packet handler failed with error {source:?}")]
     PacketHandlerFailure {
+        /// The source error that caused the packet handler failure.
         source: Box<dyn std::error::Error + Send + Sync + 'static>,
     },
 
     /// An error indicating that the library failed to build a data stream within a stream builder utility function.
     #[error("Failed to build input data stream with error {source:?}")]
     StreamBuildError {
+        /// The source error that caused the stream build error.
         source: Box<dyn std::error::Error + Send + Sync + 'static>,
+        /// The description of the stream build error.
         description: String,
     },
 
@@ -40,12 +46,16 @@ pub enum Error {
     /// due to the packet buffer being too small to contain a header.
     #[error("Failed to remove packet header from packet buffer due to insufficient data length: {packet}")]
     InsufficientPacketBufferLength {
+        /// The packet that is too small to contain a header.
         packet: EncodedToRadioPacketWithHeader,
     },
 
+    /// An error indicating that a function was passed a parameter that is not valid.
     #[error("Invalid function parameter: {source:?}")]
     InvalidParameter {
+        /// The source error that caused the invalid parameter error.
         source: Box<dyn std::error::Error + Send + Sync + 'static>,
+        /// The description of the invalid parameter.
         description: String,
     },
 
@@ -102,6 +112,7 @@ pub enum InternalChannelError {
     #[error(transparent)]
     IncomingStreamDataWriteError(#[from] tokio::sync::mpsc::error::SendError<IncomingStreamData>),
 
+    /// An error indicating that a channel was closed prematurely.
     #[error("Channel unexpectedly closed")]
     ChannelClosedEarly,
 }

--- a/src/errors_internal.rs
+++ b/src/errors_internal.rs
@@ -39,8 +39,13 @@ pub enum Error {
     },
 
     /// An error indicating that too much data is being sent.
+    /// NOTE: This error name is misspelled and should be treated as if it is `InvalidDataSize`.
     #[error("Trying to send too much data")]
     InvalidaDataSize { data_length: usize },
+    InvalidaDataSize {
+        /// The length of the data of invalid size.
+        data_length: usize,
+    },
 
     /// An error indicating that the method failed to remove a packet header from a packet buffer
     /// due to the packet buffer being too small to contain a header.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,12 +159,10 @@ pub mod utils {
 /// represents the payload data of a packet that is intended to be sent to the radio. This
 /// struct includes the required packet header, and can be sent to the radio.
 pub mod types {
-    pub use crate::connections::wrappers::NodeId;
-
-    pub use crate::connections::wrappers::mesh_channel::MeshChannel;
-
     pub use crate::connections::wrappers::encoded_data::EncodedMeshPacketData;
     pub use crate::connections::wrappers::encoded_data::EncodedToRadioPacket;
     pub use crate::connections::wrappers::encoded_data::EncodedToRadioPacketWithHeader;
     pub use crate::connections::wrappers::encoded_data::IncomingStreamData;
+    pub use crate::connections::wrappers::mesh_channel::MeshChannel;
+    pub use crate::connections::wrappers::NodeId;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+//! A Rust library for communicating with and configuring Meshtastic devices.
 pub(crate) mod connections;
 pub(crate) mod errors_internal;
 pub(crate) mod utils_internal;


### PR DESCRIPTION
**Summary**

Adds the following lint to `Cargo.toml` and corrects all cases of it.

```
[lints.rust]
missing_docs = "warn"
```

**Checklist**
- [x] Tests pass locally
- [x] Documentation updated if needed
