### PR TITLE
Fixes and improvements to `meshtastic.rs` generation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -44,30 +44,20 @@ fn main() -> std::io::Result<()> {
     protos.sort();
 
     let mut config = prost_build::Config::new();
-
-    let mut derive_string = String::from("#[derive(");
-
-    #[cfg(feature = "serde")]
-    {
-        derive_string.push_str("serde::Serialize, serde::Deserialize, ");
-    }
-
-    #[cfg(feature = "ts-gen")]
-    {
-        derive_string.push_str("specta::Type, ");
-    }
-
-    derive_string.push_str(")]");
-
-    config.type_attribute(".", derive_string.as_str());
-
-    #[cfg(feature = "serde")]
-    {
-        config.type_attribute(".", "#[serde(rename_all = \"camelCase\")]");
-        config.type_attribute(".", "#[allow(clippy::doc_lazy_continuation)]");
-        config.type_attribute(".", "#[allow(clippy::empty_docs)]");
-        config.type_attribute(".", "#[allow(clippy::doc_overindented_list_items)]");
-    }
+    config.type_attribute(
+        ".",
+        "#[cfg_attr(feature = \"serde\", derive(serde::Serialize, serde::Deserialize))]",
+    );
+    config.type_attribute(
+        ".",
+        "#[cfg_attr(feature = \"serde\", serde(rename_all = \"camelCase\"))]",
+    );
+    config.type_attribute(
+        ".",
+        "#[cfg_attr(feature = \"ts-gen\", derive(specta::Type))]",
+    );
+    config.type_attribute(".", "#[allow(clippy::doc_lazy_continuation)]");
+    config.type_attribute(".", "#[allow(clippy::empty_docs)]");
 
     config.out_dir(gen_dir);
     config.compile_protos(&protos, &[protobufs_dir])

--- a/build.rs
+++ b/build.rs
@@ -56,8 +56,6 @@ fn main() -> std::io::Result<()> {
         ".",
         "#[cfg_attr(feature = \"ts-gen\", derive(specta::Type))]",
     );
-    config.type_attribute(".", "#[allow(clippy::doc_lazy_continuation)]");
-    config.type_attribute(".", "#[allow(clippy::empty_docs)]");
 
     config.out_dir(gen_dir);
     config.compile_protos(&protos, &[protobufs_dir])

--- a/src/generated/meshtastic.rs
+++ b/src/generated/meshtastic.rs
@@ -18,8 +18,6 @@
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChannelSettings {
     ///
@@ -83,8 +81,6 @@ pub struct ChannelSettings {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct ModuleSettings {
     ///
@@ -102,8 +98,6 @@ pub struct ModuleSettings {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Channel {
     ///
@@ -136,8 +130,6 @@ pub mod channel {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(
         Clone,
         Copy,
@@ -188,8 +180,6 @@ pub mod channel {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeviceUiConfig {
     ///
@@ -244,8 +234,6 @@ pub struct DeviceUiConfig {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NodeFilter {
     ///
@@ -280,8 +268,6 @@ pub struct NodeFilter {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NodeHighlight {
     ///
@@ -308,8 +294,6 @@ pub struct NodeHighlight {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum Theme {
@@ -350,8 +334,6 @@ impl Theme {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum Language {
@@ -465,8 +447,6 @@ impl Language {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Config {
     ///
@@ -481,8 +461,6 @@ pub mod config {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct DeviceConfig {
         ///
@@ -545,8 +523,6 @@ pub mod config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-        #[allow(clippy::doc_lazy_continuation)]
-        #[allow(clippy::empty_docs)]
         #[derive(
             Clone,
             Copy,
@@ -669,8 +645,6 @@ pub mod config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-        #[allow(clippy::doc_lazy_continuation)]
-        #[allow(clippy::empty_docs)]
         #[derive(
             Clone,
             Copy,
@@ -742,8 +716,6 @@ pub mod config {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
     pub struct PositionConfig {
         ///
@@ -819,8 +791,6 @@ pub mod config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-        #[allow(clippy::doc_lazy_continuation)]
-        #[allow(clippy::empty_docs)]
         #[derive(
             Clone,
             Copy,
@@ -913,8 +883,6 @@ pub mod config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-        #[allow(clippy::doc_lazy_continuation)]
-        #[allow(clippy::empty_docs)]
         #[derive(
             Clone,
             Copy,
@@ -967,8 +935,6 @@ pub mod config {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
     pub struct PowerConfig {
         ///
@@ -1025,8 +991,6 @@ pub mod config {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct NetworkConfig {
         ///
@@ -1072,8 +1036,6 @@ pub mod config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-        #[allow(clippy::doc_lazy_continuation)]
-        #[allow(clippy::empty_docs)]
         #[derive(Clone, Copy, PartialEq, ::prost::Message)]
         pub struct IpV4Config {
             ///
@@ -1096,8 +1058,6 @@ pub mod config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-        #[allow(clippy::doc_lazy_continuation)]
-        #[allow(clippy::empty_docs)]
         #[derive(
             Clone,
             Copy,
@@ -1143,8 +1103,6 @@ pub mod config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-        #[allow(clippy::doc_lazy_continuation)]
-        #[allow(clippy::empty_docs)]
         #[derive(
             Clone,
             Copy,
@@ -1191,8 +1149,6 @@ pub mod config {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
     pub struct DisplayConfig {
         ///
@@ -1255,8 +1211,6 @@ pub mod config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-        #[allow(clippy::doc_lazy_continuation)]
-        #[allow(clippy::empty_docs)]
         #[derive(
             Clone,
             Copy,
@@ -1329,8 +1283,6 @@ pub mod config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-        #[allow(clippy::doc_lazy_continuation)]
-        #[allow(clippy::empty_docs)]
         #[derive(
             Clone,
             Copy,
@@ -1376,8 +1328,6 @@ pub mod config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-        #[allow(clippy::doc_lazy_continuation)]
-        #[allow(clippy::empty_docs)]
         #[derive(
             Clone,
             Copy,
@@ -1431,8 +1381,6 @@ pub mod config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-        #[allow(clippy::doc_lazy_continuation)]
-        #[allow(clippy::empty_docs)]
         #[derive(
             Clone,
             Copy,
@@ -1486,8 +1434,6 @@ pub mod config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-        #[allow(clippy::doc_lazy_continuation)]
-        #[allow(clippy::empty_docs)]
         #[derive(
             Clone,
             Copy,
@@ -1564,8 +1510,6 @@ pub mod config {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct LoRaConfig {
         ///
@@ -1677,8 +1621,6 @@ pub mod config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-        #[allow(clippy::doc_lazy_continuation)]
-        #[allow(clippy::empty_docs)]
         #[derive(
             Clone,
             Copy,
@@ -1825,8 +1767,6 @@ pub mod config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-        #[allow(clippy::doc_lazy_continuation)]
-        #[allow(clippy::empty_docs)]
         #[derive(
             Clone,
             Copy,
@@ -1909,8 +1849,6 @@ pub mod config {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
     pub struct BluetoothConfig {
         ///
@@ -1931,8 +1869,6 @@ pub mod config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-        #[allow(clippy::doc_lazy_continuation)]
-        #[allow(clippy::empty_docs)]
         #[derive(
             Clone,
             Copy,
@@ -1982,8 +1918,6 @@ pub mod config {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct SecurityConfig {
         ///
@@ -2024,8 +1958,6 @@ pub mod config {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
     pub struct SessionkeyConfig {}
     ///
@@ -2033,8 +1965,6 @@ pub mod config {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum PayloadVariant {
         #[prost(message, tag = "1")]
@@ -2062,8 +1992,6 @@ pub mod config {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeviceConnectionStatus {
     ///
@@ -2088,8 +2016,6 @@ pub struct DeviceConnectionStatus {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WifiConnectionStatus {
     ///
@@ -2110,8 +2036,6 @@ pub struct WifiConnectionStatus {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct EthernetConnectionStatus {
     ///
@@ -2124,8 +2048,6 @@ pub struct EthernetConnectionStatus {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct NetworkConnectionStatus {
     ///
@@ -2150,8 +2072,6 @@ pub struct NetworkConnectionStatus {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct BluetoothConnectionStatus {
     ///
@@ -2172,8 +2092,6 @@ pub struct BluetoothConnectionStatus {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct SerialConnectionStatus {
     ///
@@ -2190,8 +2108,6 @@ pub struct SerialConnectionStatus {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ModuleConfig {
     ///
@@ -2209,8 +2125,6 @@ pub mod module_config {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct MqttConfig {
         ///
@@ -2273,8 +2187,6 @@ pub mod module_config {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
     pub struct MapReportSettings {
         ///
@@ -2291,8 +2203,6 @@ pub mod module_config {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct RemoteHardwareConfig {
         ///
@@ -2313,8 +2223,6 @@ pub mod module_config {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
     pub struct NeighborInfoConfig {
         ///
@@ -2337,8 +2245,6 @@ pub mod module_config {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct DetectionSensorConfig {
         ///
@@ -2387,8 +2293,6 @@ pub mod module_config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-        #[allow(clippy::doc_lazy_continuation)]
-        #[allow(clippy::empty_docs)]
         #[derive(
             Clone,
             Copy,
@@ -2451,8 +2355,6 @@ pub mod module_config {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
     pub struct AudioConfig {
         ///
@@ -2491,8 +2393,6 @@ pub mod module_config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-        #[allow(clippy::doc_lazy_continuation)]
-        #[allow(clippy::empty_docs)]
         #[derive(
             Clone,
             Copy,
@@ -2556,8 +2456,6 @@ pub mod module_config {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
     pub struct PaxcounterConfig {
         ///
@@ -2580,8 +2478,6 @@ pub mod module_config {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
     pub struct SerialConfig {
         ///
@@ -2626,8 +2522,6 @@ pub mod module_config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-        #[allow(clippy::doc_lazy_continuation)]
-        #[allow(clippy::empty_docs)]
         #[derive(
             Clone,
             Copy,
@@ -2711,8 +2605,6 @@ pub mod module_config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-        #[allow(clippy::doc_lazy_continuation)]
-        #[allow(clippy::empty_docs)]
         #[derive(
             Clone,
             Copy,
@@ -2772,8 +2664,6 @@ pub mod module_config {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
     pub struct ExternalNotificationConfig {
         ///
@@ -2853,8 +2743,6 @@ pub mod module_config {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
     pub struct StoreForwardConfig {
         ///
@@ -2887,8 +2775,6 @@ pub mod module_config {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
     pub struct RangeTestConfig {
         ///
@@ -2910,8 +2796,6 @@ pub mod module_config {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
     pub struct TelemetryConfig {
         ///
@@ -2977,8 +2861,6 @@ pub mod module_config {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct CannedMessageConfig {
         ///
@@ -3035,8 +2917,6 @@ pub mod module_config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-        #[allow(clippy::doc_lazy_continuation)]
-        #[allow(clippy::empty_docs)]
         #[derive(
             Clone,
             Copy,
@@ -3114,8 +2994,6 @@ pub mod module_config {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
     pub struct AmbientLightingConfig {
         ///
@@ -3144,8 +3022,6 @@ pub mod module_config {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum PayloadVariant {
         ///
@@ -3207,8 +3083,6 @@ pub mod module_config {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RemoteHardwarePin {
     ///
@@ -3227,8 +3101,6 @@ pub struct RemoteHardwarePin {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum RemoteHardwarePinType {
@@ -3280,8 +3152,6 @@ impl RemoteHardwarePinType {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum PortNum {
@@ -3508,8 +3378,6 @@ impl PortNum {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct DeviceMetrics {
     ///
@@ -3538,8 +3406,6 @@ pub struct DeviceMetrics {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct EnvironmentMetrics {
     ///
@@ -3630,8 +3496,6 @@ pub struct EnvironmentMetrics {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct PowerMetrics {
     ///
@@ -3664,8 +3528,6 @@ pub struct PowerMetrics {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct AirQualityMetrics {
     ///
@@ -3726,8 +3588,6 @@ pub struct AirQualityMetrics {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct LocalStats {
     ///
@@ -3782,8 +3642,6 @@ pub struct LocalStats {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct HealthMetrics {
     ///
@@ -3804,8 +3662,6 @@ pub struct HealthMetrics {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct Telemetry {
     ///
@@ -3820,8 +3676,6 @@ pub mod telemetry {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Oneof)]
     pub enum Variant {
         ///
@@ -3855,8 +3709,6 @@ pub mod telemetry {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct Nau7802Config {
     ///
@@ -3873,8 +3725,6 @@ pub struct Nau7802Config {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum TelemetrySensorType {
@@ -4078,8 +3928,6 @@ impl TelemetrySensorType {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct XModem {
     #[prost(enumeration = "x_modem::Control", tag = "1")]
@@ -4096,8 +3944,6 @@ pub mod x_modem {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(
         Clone,
         Copy,
@@ -4158,8 +4004,6 @@ pub mod x_modem {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct Position {
     ///
@@ -4281,8 +4125,6 @@ pub mod position {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(
         Clone,
         Copy,
@@ -4339,8 +4181,6 @@ pub mod position {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(
         Clone,
         Copy,
@@ -4421,8 +4261,6 @@ pub mod position {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct User {
     ///
@@ -4476,8 +4314,6 @@ pub struct User {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RouteDiscovery {
     ///
@@ -4502,8 +4338,6 @@ pub struct RouteDiscovery {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Routing {
     #[prost(oneof = "routing::Variant", tags = "1, 2, 3")]
@@ -4517,8 +4351,6 @@ pub mod routing {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(
         Clone,
         Copy,
@@ -4634,8 +4466,6 @@ pub mod routing {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Variant {
         ///
@@ -4660,8 +4490,6 @@ pub mod routing {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Data {
     ///
@@ -4716,8 +4544,6 @@ pub struct Data {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Waypoint {
     ///
@@ -4759,8 +4585,6 @@ pub struct Waypoint {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MqttClientProxyMessage {
     ///
@@ -4785,8 +4609,6 @@ pub mod mqtt_client_proxy_message {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum PayloadVariant {
         ///
@@ -4806,8 +4628,6 @@ pub mod mqtt_client_proxy_message {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MeshPacket {
     ///
@@ -4947,8 +4767,6 @@ pub mod mesh_packet {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(
         Clone,
         Copy,
@@ -5038,8 +4856,6 @@ pub mod mesh_packet {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(
         Clone,
         Copy,
@@ -5088,8 +4904,6 @@ pub mod mesh_packet {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum PayloadVariant {
         ///
@@ -5122,8 +4936,6 @@ pub mod mesh_packet {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NodeInfo {
     ///
@@ -5182,8 +4994,6 @@ pub struct NodeInfo {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MyNodeInfo {
     ///
@@ -5219,8 +5029,6 @@ pub struct MyNodeInfo {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LogRecord {
     ///
@@ -5247,8 +5055,6 @@ pub mod log_record {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(
         Clone,
         Copy,
@@ -5318,8 +5124,6 @@ pub mod log_record {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct QueueStatus {
     /// Last attempt to queue status, ErrorCode
@@ -5343,8 +5147,6 @@ pub struct QueueStatus {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FromRadio {
     ///
@@ -5367,8 +5169,6 @@ pub mod from_radio {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum PayloadVariant {
         ///
@@ -5453,8 +5253,6 @@ pub mod from_radio {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ClientNotification {
     ///
@@ -5479,8 +5277,6 @@ pub struct ClientNotification {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileInfo {
     ///
@@ -5498,8 +5294,6 @@ pub struct FileInfo {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ToRadio {
     ///
@@ -5514,8 +5308,6 @@ pub mod to_radio {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum PayloadVariant {
         ///
@@ -5556,8 +5348,6 @@ pub mod to_radio {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Compressed {
     ///
@@ -5574,8 +5364,6 @@ pub struct Compressed {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NeighborInfo {
     ///
@@ -5600,8 +5388,6 @@ pub struct NeighborInfo {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct Neighbor {
     ///
@@ -5628,8 +5414,6 @@ pub struct Neighbor {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeviceMetadata {
     ///
@@ -5688,8 +5472,6 @@ pub struct DeviceMetadata {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct Heartbeat {}
 ///
@@ -5697,8 +5479,6 @@ pub struct Heartbeat {}
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NodeRemoteHardwarePin {
     ///
@@ -5713,8 +5493,6 @@ pub struct NodeRemoteHardwarePin {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChunkedPayload {
     ///
@@ -5739,8 +5517,6 @@ pub struct ChunkedPayload {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResendChunks {
     #[prost(uint32, repeated, tag = "1")]
@@ -5751,8 +5527,6 @@ pub struct ResendChunks {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChunkedPayloadResponse {
     ///
@@ -5769,8 +5543,6 @@ pub mod chunked_payload_response {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum PayloadVariant {
         ///
@@ -5795,8 +5567,6 @@ pub mod chunked_payload_response {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum HardwareModel {
@@ -6293,8 +6063,6 @@ impl HardwareModel {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum Constants {
@@ -6336,8 +6104,6 @@ impl Constants {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum CriticalErrorCode {
@@ -6440,8 +6206,6 @@ impl CriticalErrorCode {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum ExcludedModules {
@@ -6539,8 +6303,6 @@ impl ExcludedModules {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AdminMessage {
     ///
@@ -6564,8 +6326,6 @@ pub mod admin_message {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(
         Clone,
         Copy,
@@ -6651,8 +6411,6 @@ pub mod admin_message {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(
         Clone,
         Copy,
@@ -6753,8 +6511,6 @@ pub mod admin_message {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum PayloadVariant {
         ///
@@ -6966,8 +6722,6 @@ pub mod admin_message {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HamParameters {
     ///
@@ -6994,8 +6748,6 @@ pub struct HamParameters {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NodeRemoteHardwarePinsResponse {
     ///
@@ -7012,8 +6764,6 @@ pub struct NodeRemoteHardwarePinsResponse {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChannelSet {
     ///
@@ -7030,8 +6780,6 @@ pub struct ChannelSet {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TakPacket {
     ///
@@ -7062,8 +6810,6 @@ pub mod tak_packet {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum PayloadVariant {
         ///
@@ -7086,8 +6832,6 @@ pub mod tak_packet {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GeoChat {
     ///
@@ -7109,8 +6853,6 @@ pub struct GeoChat {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct Group {
     ///
@@ -7129,8 +6871,6 @@ pub struct Group {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct Status {
     ///
@@ -7144,8 +6884,6 @@ pub struct Status {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Contact {
     ///
@@ -7165,8 +6903,6 @@ pub struct Contact {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct Pli {
     ///
@@ -7195,8 +6931,6 @@ pub struct Pli {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum Team {
@@ -7297,8 +7031,6 @@ impl Team {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum MemberRole {
@@ -7369,8 +7101,6 @@ impl MemberRole {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CannedMessageModuleConfig {
     ///
@@ -7381,8 +7111,6 @@ pub struct CannedMessageModuleConfig {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LocalConfig {
     ///
@@ -7427,8 +7155,6 @@ pub struct LocalConfig {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LocalModuleConfig {
     ///
@@ -7498,8 +7224,6 @@ pub struct LocalModuleConfig {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeviceProfile {
     ///
@@ -7540,8 +7264,6 @@ pub struct DeviceProfile {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct PositionLite {
     ///
@@ -7573,8 +7295,6 @@ pub struct PositionLite {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UserLite {
     ///
@@ -7617,8 +7337,6 @@ pub struct UserLite {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NodeInfoLite {
     ///
@@ -7683,8 +7401,6 @@ pub struct NodeInfoLite {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeviceState {
     ///
@@ -7744,8 +7460,6 @@ pub struct DeviceState {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChannelFile {
     ///
@@ -7764,8 +7478,6 @@ pub struct ChannelFile {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ServiceEnvelope {
     ///
@@ -7788,8 +7500,6 @@ pub struct ServiceEnvelope {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MapReport {
     ///
@@ -7852,8 +7562,6 @@ pub struct MapReport {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct Paxcount {
     ///
@@ -7874,8 +7582,6 @@ pub struct Paxcount {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct PowerMon {}
 /// Nested message and enum types in `PowerMon`.
@@ -7885,8 +7591,6 @@ pub mod power_mon {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(
         Clone,
         Copy,
@@ -7974,8 +7678,6 @@ pub mod power_mon {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct PowerStressMessage {
     ///
@@ -7994,8 +7696,6 @@ pub mod power_stress_message {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(
         Clone,
         Copy,
@@ -8121,8 +7821,6 @@ pub mod power_stress_message {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct HardwareMessage {
     ///
@@ -8146,8 +7844,6 @@ pub mod hardware_message {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(
         Clone,
         Copy,
@@ -8216,8 +7912,6 @@ pub mod hardware_message {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RtttlConfig {
     ///
@@ -8230,8 +7924,6 @@ pub struct RtttlConfig {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-#[allow(clippy::doc_lazy_continuation)]
-#[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StoreAndForward {
     ///
@@ -8250,8 +7942,6 @@ pub mod store_and_forward {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
     pub struct Statistics {
         ///
@@ -8296,8 +7986,6 @@ pub mod store_and_forward {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
     pub struct History {
         ///
@@ -8319,8 +8007,6 @@ pub mod store_and_forward {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
     pub struct Heartbeat {
         ///
@@ -8338,8 +8024,6 @@ pub mod store_and_forward {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(
         Clone,
         Copy,
@@ -8457,8 +8141,6 @@ pub mod store_and_forward {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
-    #[allow(clippy::doc_lazy_continuation)]
-    #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Variant {
         ///

--- a/src/generated/meshtastic.rs
+++ b/src/generated/meshtastic.rs
@@ -15,8 +15,9 @@
 /// FIXME: Add description of multi-channel support and how primary vs secondary channels are used.
 /// FIXME: explain how apps use channels for security.
 /// explain how remote settings and remote gpio are managed as an example
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -79,8 +80,9 @@ pub struct ChannelSettings {
 }
 ///
 /// This message is specifically for modules to store per-channel configuration data.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -97,8 +99,9 @@ pub struct ModuleSettings {
 }
 ///
 /// A pair of a channel number, mode and the (sharable) settings for that channel
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -130,8 +133,9 @@ pub mod channel {
     /// cross band routing as needed.
     /// If a device has only a single radio (the common case) only one channel can be PRIMARY at a time
     /// (but any number of SECONDARY channels can't be sent received on that common frequency)
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(
@@ -181,8 +185,9 @@ pub mod channel {
         }
     }
 }
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -236,8 +241,9 @@ pub struct DeviceUiConfig {
     #[prost(bytes = "vec", tag = "14")]
     pub calibration_data: ::prost::alloc::vec::Vec<u8>,
 }
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -271,8 +277,9 @@ pub struct NodeFilter {
     #[prost(int32, tag = "7")]
     pub channel: i32,
 }
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -298,8 +305,9 @@ pub struct NodeHighlight {
     #[prost(string, tag = "5")]
     pub node_name: ::prost::alloc::string::String,
 }
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -339,8 +347,9 @@ impl Theme {
 }
 ///
 /// Localization
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -453,8 +462,9 @@ impl Language {
         }
     }
 }
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -468,8 +478,9 @@ pub struct Config {
 pub mod config {
     ///
     /// Configuration
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -531,8 +542,9 @@ pub mod config {
     pub mod device_config {
         ///
         /// Defines the device's role on the Mesh network
-        #[derive(serde::Serialize, serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[allow(clippy::doc_lazy_continuation)]
         #[allow(clippy::empty_docs)]
         #[derive(
@@ -654,8 +666,9 @@ pub mod config {
         }
         ///
         /// Defines the device's behavior for how messages are rebroadcast
-        #[derive(serde::Serialize, serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[allow(clippy::doc_lazy_continuation)]
         #[allow(clippy::empty_docs)]
         #[derive(
@@ -726,8 +739,9 @@ pub mod config {
     }
     ///
     /// Position Config
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -802,8 +816,9 @@ pub mod config {
         /// are always included (also time if GPS-synced)
         /// NOTE: the more fields are included, the larger the message will be -
         ///    leading to longer airtime and a higher risk of packet loss
-        #[derive(serde::Serialize, serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[allow(clippy::doc_lazy_continuation)]
         #[allow(clippy::empty_docs)]
         #[derive(
@@ -895,8 +910,9 @@ pub mod config {
                 }
             }
         }
-        #[derive(serde::Serialize, serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[allow(clippy::doc_lazy_continuation)]
         #[allow(clippy::empty_docs)]
         #[derive(
@@ -948,8 +964,9 @@ pub mod config {
     ///
     /// Power Config\
     /// See [Power Config](/docs/settings/config/power) for additional power config details.
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -1005,8 +1022,9 @@ pub mod config {
     }
     ///
     /// Network Config
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1051,8 +1069,9 @@ pub mod config {
     }
     /// Nested message and enum types in `NetworkConfig`.
     pub mod network_config {
-        #[derive(serde::Serialize, serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[allow(clippy::doc_lazy_continuation)]
         #[allow(clippy::empty_docs)]
         #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -1074,8 +1093,9 @@ pub mod config {
             #[prost(fixed32, tag = "4")]
             pub dns: u32,
         }
-        #[derive(serde::Serialize, serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[allow(clippy::doc_lazy_continuation)]
         #[allow(clippy::empty_docs)]
         #[derive(
@@ -1120,8 +1140,9 @@ pub mod config {
         }
         ///
         /// Available flags auxiliary network protocols
-        #[derive(serde::Serialize, serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[allow(clippy::doc_lazy_continuation)]
         #[allow(clippy::empty_docs)]
         #[derive(
@@ -1167,8 +1188,9 @@ pub mod config {
     }
     ///
     /// Display Config
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -1230,8 +1252,9 @@ pub mod config {
     pub mod display_config {
         ///
         /// How the GPS coordinates are displayed on the OLED screen.
-        #[derive(serde::Serialize, serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[allow(clippy::doc_lazy_continuation)]
         #[allow(clippy::empty_docs)]
         #[derive(
@@ -1303,8 +1326,9 @@ pub mod config {
         }
         ///
         /// Unit display preference
-        #[derive(serde::Serialize, serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[allow(clippy::doc_lazy_continuation)]
         #[allow(clippy::empty_docs)]
         #[derive(
@@ -1349,8 +1373,9 @@ pub mod config {
         }
         ///
         /// Override OLED outo detect with this if it fails.
-        #[derive(serde::Serialize, serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[allow(clippy::doc_lazy_continuation)]
         #[allow(clippy::empty_docs)]
         #[derive(
@@ -1403,8 +1428,9 @@ pub mod config {
                 }
             }
         }
-        #[derive(serde::Serialize, serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[allow(clippy::doc_lazy_continuation)]
         #[allow(clippy::empty_docs)]
         #[derive(
@@ -1457,8 +1483,9 @@ pub mod config {
                 }
             }
         }
-        #[derive(serde::Serialize, serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[allow(clippy::doc_lazy_continuation)]
         #[allow(clippy::empty_docs)]
         #[derive(
@@ -1534,8 +1561,9 @@ pub mod config {
     }
     ///
     /// Lora Config
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1646,8 +1674,9 @@ pub mod config {
     }
     /// Nested message and enum types in `LoRaConfig`.
     pub mod lo_ra_config {
-        #[derive(serde::Serialize, serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[allow(clippy::doc_lazy_continuation)]
         #[allow(clippy::empty_docs)]
         #[derive(
@@ -1793,8 +1822,9 @@ pub mod config {
         ///
         /// Standard predefined channel settings
         /// Note: these mappings must match ModemPreset Choice in the device code.
-        #[derive(serde::Serialize, serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[allow(clippy::doc_lazy_continuation)]
         #[allow(clippy::empty_docs)]
         #[derive(
@@ -1876,8 +1906,9 @@ pub mod config {
             }
         }
     }
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -1897,8 +1928,9 @@ pub mod config {
     }
     /// Nested message and enum types in `BluetoothConfig`.
     pub mod bluetooth_config {
-        #[derive(serde::Serialize, serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[allow(clippy::doc_lazy_continuation)]
         #[allow(clippy::empty_docs)]
         #[derive(
@@ -1947,8 +1979,9 @@ pub mod config {
             }
         }
     }
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1988,16 +2021,18 @@ pub mod config {
     }
     ///
     /// Blank config request, strictly for getting the session key
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
     pub struct SessionkeyConfig {}
     ///
     /// Payload Variant
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
@@ -2024,8 +2059,9 @@ pub mod config {
         DeviceUi(super::DeviceUiConfig),
     }
 }
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2049,8 +2085,9 @@ pub struct DeviceConnectionStatus {
 }
 ///
 /// WiFi connection status
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2070,8 +2107,9 @@ pub struct WifiConnectionStatus {
 }
 ///
 /// Ethernet connection status
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -2083,8 +2121,9 @@ pub struct EthernetConnectionStatus {
 }
 ///
 /// Ethernet or WiFi connection status
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -2108,8 +2147,9 @@ pub struct NetworkConnectionStatus {
 }
 ///
 /// Bluetooth connection status
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -2129,8 +2169,9 @@ pub struct BluetoothConnectionStatus {
 }
 ///
 /// Serial connection status
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -2146,8 +2187,9 @@ pub struct SerialConnectionStatus {
 }
 ///
 /// Module Config
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2164,8 +2206,9 @@ pub struct ModuleConfig {
 pub mod module_config {
     ///
     /// MQTT Client Config
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2227,8 +2270,9 @@ pub mod module_config {
     }
     ///
     /// Settings for reporting unencrypted information about our node to a map via MQTT
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -2244,8 +2288,9 @@ pub mod module_config {
     }
     ///
     /// RemoteHardwareModule Config
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2265,8 +2310,9 @@ pub mod module_config {
     }
     ///
     /// NeighborInfoModule Config
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -2288,8 +2334,9 @@ pub mod module_config {
     }
     ///
     /// Detection Sensor Module Config
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2337,8 +2384,9 @@ pub mod module_config {
     }
     /// Nested message and enum types in `DetectionSensorConfig`.
     pub mod detection_sensor_config {
-        #[derive(serde::Serialize, serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[allow(clippy::doc_lazy_continuation)]
         #[allow(clippy::empty_docs)]
         #[derive(
@@ -2400,8 +2448,9 @@ pub mod module_config {
     }
     ///
     /// Audio Config for codec2 voice
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -2439,8 +2488,9 @@ pub mod module_config {
     pub mod audio_config {
         ///
         /// Baudrate for codec2 voice
-        #[derive(serde::Serialize, serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[allow(clippy::doc_lazy_continuation)]
         #[allow(clippy::empty_docs)]
         #[derive(
@@ -2503,8 +2553,9 @@ pub mod module_config {
     }
     ///
     /// Config for the Paxcounter Module
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -2526,8 +2577,9 @@ pub mod module_config {
     }
     ///
     /// Serial Config
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -2571,8 +2623,9 @@ pub mod module_config {
     pub mod serial_config {
         ///
         /// TODO: REPLACE
-        #[derive(serde::Serialize, serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[allow(clippy::doc_lazy_continuation)]
         #[allow(clippy::empty_docs)]
         #[derive(
@@ -2655,8 +2708,9 @@ pub mod module_config {
         }
         ///
         /// TODO: REPLACE
-        #[derive(serde::Serialize, serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[allow(clippy::doc_lazy_continuation)]
         #[allow(clippy::empty_docs)]
         #[derive(
@@ -2715,8 +2769,9 @@ pub mod module_config {
     }
     ///
     /// External Notifications Config
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -2795,8 +2850,9 @@ pub mod module_config {
     }
     ///
     /// Store and Forward Module Config
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -2828,8 +2884,9 @@ pub mod module_config {
     }
     ///
     /// Preferences for the RangeTestModule
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -2850,8 +2907,9 @@ pub mod module_config {
     }
     ///
     /// Configuration for both device and environment metrics
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -2916,8 +2974,9 @@ pub mod module_config {
     }
     ///
     /// Canned Messages Module Config
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2973,8 +3032,9 @@ pub mod module_config {
     pub mod canned_message_config {
         ///
         /// TODO: REPLACE
-        #[derive(serde::Serialize, serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[allow(clippy::doc_lazy_continuation)]
         #[allow(clippy::empty_docs)]
         #[derive(
@@ -3051,8 +3111,9 @@ pub mod module_config {
     ///
     /// Ambient Lighting Module - Settings for control of onboard LEDs to allow users to adjust the brightness levels and respective color levels.
     /// Initially created for the RAK14001 RGB LED module.
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -3080,8 +3141,9 @@ pub mod module_config {
     }
     ///
     /// TODO: REPLACE
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
@@ -3142,8 +3204,9 @@ pub mod module_config {
 }
 ///
 /// A GPIO pin definition for remote hardware module
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -3161,8 +3224,9 @@ pub struct RemoteHardwarePin {
     #[prost(enumeration = "RemoteHardwarePinType", tag = "3")]
     pub r#type: i32,
 }
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -3213,8 +3277,9 @@ impl RemoteHardwarePinType {
 /// Note: This was formerly a Type enum named 'typ' with the same id #
 /// We have change to this 'portnum' based scheme for specifying app handlers for particular payloads.
 /// This change is backwards compatible by treating the legacy OPAQUE/CLEAR_TEXT values identically.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -3440,8 +3505,9 @@ impl PortNum {
 }
 ///
 /// Key native device metrics such as battery level
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -3469,8 +3535,9 @@ pub struct DeviceMetrics {
 }
 ///
 /// Weather station or other environmental metrics
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -3560,8 +3627,9 @@ pub struct EnvironmentMetrics {
 }
 ///
 /// Power Metrics (voltage / current / etc)
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -3593,8 +3661,9 @@ pub struct PowerMetrics {
 }
 ///
 /// Air quality metrics
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -3654,8 +3723,9 @@ pub struct AirQualityMetrics {
 }
 ///
 /// Local device mesh statistics
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -3709,8 +3779,9 @@ pub struct LocalStats {
 }
 ///
 /// Health telemetry metrics
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -3730,8 +3801,9 @@ pub struct HealthMetrics {
 }
 ///
 /// Types of Measurements the telemetry module is equipped to handle
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -3745,8 +3817,9 @@ pub struct Telemetry {
 }
 /// Nested message and enum types in `Telemetry`.
 pub mod telemetry {
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Oneof)]
@@ -3779,8 +3852,9 @@ pub mod telemetry {
 }
 ///
 /// NAU7802 Telemetry configuration, for saving to flash
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -3796,8 +3870,9 @@ pub struct Nau7802Config {
 }
 ///
 /// Supported I2C Sensors for telemetry in Meshtastic
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -4000,8 +4075,9 @@ impl TelemetrySensorType {
         }
     }
 }
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -4017,8 +4093,9 @@ pub struct XModem {
 }
 /// Nested message and enum types in `XModem`.
 pub mod x_modem {
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(
@@ -4078,8 +4155,9 @@ pub mod x_modem {
 }
 ///
 /// A GPS Position
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -4132,7 +4210,7 @@ pub struct Position {
     /// Horizontal, Vertical and Position Dilution of Precision, in 1/100 units
     /// - PDOP is sufficient for most cases
     /// - for higher precision scenarios, HDOP and VDOP can be used instead,
-    ///  in which case PDOP becomes redundant (PDOP=sqrt(HDOP^2 + VDOP^2))
+    ///    in which case PDOP becomes redundant (PDOP=sqrt(HDOP^2 + VDOP^2))
     /// TODO: REMOVE/INTEGRATE
     #[prost(uint32, tag = "11")]
     pub pdop: u32,
@@ -4183,12 +4261,12 @@ pub struct Position {
     /// Estimated/expected time (in seconds) until next update:
     /// - if we update at fixed intervals of X seconds, use X
     /// - if we update at dynamic intervals (based on relative movement etc),
-    /// but "AT LEAST every Y seconds", use Y
+    ///    but "AT LEAST every Y seconds", use Y
     #[prost(uint32, tag = "21")]
     pub next_update: u32,
     ///
     /// A sequence number, incremented with each Position message to help
-    /// detect lost updates if needed
+    ///    detect lost updates if needed
     #[prost(uint32, tag = "22")]
     pub seq_number: u32,
     ///
@@ -4200,8 +4278,9 @@ pub struct Position {
 pub mod position {
     ///
     /// How the location was acquired: manual, onboard GPS, external (EUD) GPS
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(
@@ -4257,8 +4336,9 @@ pub mod position {
     ///
     /// How the altitude was acquired: manual, GPS int/ext, etc
     /// Default: same as location_source if present
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(
@@ -4338,8 +4418,9 @@ pub mod position {
 /// A few nodenums are reserved and will never be requested:
 /// 0xff - broadcast
 /// 0 through 3 - for future use
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -4392,8 +4473,9 @@ pub struct User {
 }
 ///
 /// A message used in a traceroute
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -4417,8 +4499,9 @@ pub struct RouteDiscovery {
 }
 ///
 /// A Routing control Data packet handled by the routing module
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -4431,8 +4514,9 @@ pub mod routing {
     ///
     /// A failure in delivering a message (usually used for routing control messages, but might be provided in addition to ack.fail_id to provide
     /// details on the type of failure).
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(
@@ -4547,8 +4631,9 @@ pub mod routing {
             }
         }
     }
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
@@ -4572,8 +4657,9 @@ pub mod routing {
 /// (Formerly called SubPacket)
 /// The payload portion fo a packet, this is the actual bytes that are sent
 /// inside a radio packet (because from/to are broken out by the comms library)
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -4627,8 +4713,9 @@ pub struct Data {
 }
 ///
 /// Waypoint message, used to share arbitrary locations across the mesh
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -4669,8 +4756,9 @@ pub struct Waypoint {
 }
 ///
 /// This message will be proxied over the PhoneAPI for the client to deliver to the MQTT server
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -4694,8 +4782,9 @@ pub struct MqttClientProxyMessage {
 pub mod mqtt_client_proxy_message {
     ///
     /// The actual service envelope payload or text for mqtt pub / sub
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
@@ -4714,8 +4803,9 @@ pub mod mqtt_client_proxy_message {
 /// A packet envelope sent/received over the mesh
 /// only payload_variant is sent in the payload portion of the LORA packet.
 /// The other fields are either not sent at all, or sent in the special 16 byte LORA header.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -4854,8 +4944,9 @@ pub mod mesh_packet {
     /// So I bit the bullet and implemented a new (internal - not sent over the air)
     /// field in MeshPacket called 'priority'.
     /// And the transmission queue in the router object is now a priority queue.
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(
@@ -4944,8 +5035,9 @@ pub mod mesh_packet {
     }
     ///
     /// Identify if this is a delayed packet
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(
@@ -4993,8 +5085,9 @@ pub mod mesh_packet {
             }
         }
     }
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
@@ -5026,8 +5119,9 @@ pub mod mesh_packet {
 /// level etc) SET_CONFIG (switches device to a new set of radio params and
 /// preshared key, drops all existing nodes, force our node to rejoin this new group)
 /// Full information about a node on the mesh
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -5085,8 +5179,9 @@ pub struct NodeInfo {
 /// Unique local debugging info for this node
 /// Note: we don't include position or the user info, because that will come in the
 /// Sent to the phone in response to WantNodes.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -5121,8 +5216,9 @@ pub struct MyNodeInfo {
 /// on the message it is assumed to be a continuation of the previously sent message.
 /// This allows the device code to use fixed maxlen 64 byte strings for messages,
 /// and then extend as needed by emitting multiple records.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -5148,8 +5244,9 @@ pub struct LogRecord {
 pub mod log_record {
     ///
     /// Log levels, chosen to match python logging conventions.
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(
@@ -5218,8 +5315,9 @@ pub mod log_record {
         }
     }
 }
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -5242,8 +5340,9 @@ pub struct QueueStatus {
 /// It will support READ and NOTIFY. When a new packet arrives the device will BLE notify?
 /// It will sit in that descriptor until consumed by the phone,
 /// at which point the next item in the FIFO will be populated.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -5265,8 +5364,9 @@ pub struct FromRadio {
 pub mod from_radio {
     ///
     /// Log levels, chosen to match python logging conventions.
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
@@ -5350,8 +5450,9 @@ pub mod from_radio {
 /// To be used for important messages that should to be displayed to the user
 /// in the form of push notifications or validation messages when saving
 /// invalid configuration.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -5375,8 +5476,9 @@ pub struct ClientNotification {
 }
 ///
 /// Individual File info for the device
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -5393,8 +5495,9 @@ pub struct FileInfo {
 ///
 /// Packets/commands to the radio will be written (reliably) to the toRadio characteristic.
 /// Once the write completes the phone can assume it is handled.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -5408,8 +5511,9 @@ pub struct ToRadio {
 pub mod to_radio {
     ///
     /// Log levels, chosen to match python logging conventions.
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
@@ -5449,8 +5553,9 @@ pub mod to_radio {
 }
 ///
 /// Compressed message payload
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -5466,8 +5571,9 @@ pub struct Compressed {
 }
 ///
 /// Full info on edges for a single node
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -5491,8 +5597,9 @@ pub struct NeighborInfo {
 }
 ///
 /// A single edge in the mesh
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -5518,8 +5625,9 @@ pub struct Neighbor {
 }
 ///
 /// Device metadata response
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -5577,16 +5685,18 @@ pub struct DeviceMetadata {
 ///
 /// A heartbeat message is sent to the node from the client to keep the connection alive.
 /// This is currently only needed to keep serial connections alive, but can be used by any PhoneAPI.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct Heartbeat {}
 ///
 /// RemoteHardwarePins associated with a node
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -5600,8 +5710,9 @@ pub struct NodeRemoteHardwarePin {
     #[prost(message, optional, tag = "2")]
     pub pin: ::core::option::Option<RemoteHardwarePin>,
 }
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -5625,8 +5736,9 @@ pub struct ChunkedPayload {
 }
 ///
 /// Wrapper message for broken repeated oneof support
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -5636,8 +5748,9 @@ pub struct ResendChunks {
 }
 ///
 /// Responses to a ChunkedPayload request
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -5653,8 +5766,9 @@ pub struct ChunkedPayloadResponse {
 }
 /// Nested message and enum types in `ChunkedPayloadResponse`.
 pub mod chunked_payload_response {
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
@@ -5678,8 +5792,9 @@ pub mod chunked_payload_response {
 /// bin/build-all.sh script.
 /// Because they will be used to find firmware filenames in the android app for OTA updates.
 /// To match the old style filenames, _ is converted to -, p is converted to .
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -6175,8 +6290,9 @@ impl HardwareModel {
 }
 ///
 /// Shared constants between device and phone
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -6217,8 +6333,9 @@ impl Constants {
 /// The device might report these fault codes on the screen.
 /// If you encounter a fault code, please post on the meshtastic.discourse.group
 /// and we'll try to help.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -6320,8 +6437,9 @@ impl CriticalErrorCode {
 /// Enum for modules excluded from a device's configuration.
 /// Each value represents a ModuleConfigType that can be toggled as excluded
 /// by setting its corresponding bit in the `excluded_modules` bitmask field.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -6418,8 +6536,9 @@ impl ExcludedModules {
 /// This message is handled by the Admin module and is responsible for all settings/channel read/write operations.
 /// This message is used to do settings operations to both remote AND local nodes.
 /// (Prior to 1.2 these operations were done via special ToRadio operations)
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -6442,8 +6561,9 @@ pub struct AdminMessage {
 pub mod admin_message {
     ///
     /// TODO: REPLACE
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(
@@ -6528,8 +6648,9 @@ pub mod admin_message {
     }
     ///
     /// TODO: REPLACE
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(
@@ -6629,8 +6750,9 @@ pub mod admin_message {
     }
     ///
     /// TODO: REPLACE
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
@@ -6841,8 +6963,9 @@ pub mod admin_message {
 }
 ///
 /// Parameters for setting up Meshtastic for ameteur radio usage
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -6868,8 +6991,9 @@ pub struct HamParameters {
 }
 ///
 /// Response envelope for node_remote_hardware_pins
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -6885,8 +7009,9 @@ pub struct NodeRemoteHardwarePinsResponse {
 /// any SECONDARY channels.
 /// No DISABLED channels are included.
 /// This abstraction is used only on the the 'app side' of the world (ie python, javascript and android etc) to show a group of Channels as a (long) URL
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -6902,8 +7027,9 @@ pub struct ChannelSet {
 }
 ///
 /// Packets for the official ATAK Plugin
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -6933,8 +7059,9 @@ pub struct TakPacket {
 pub mod tak_packet {
     ///
     /// The payload of the packet
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
@@ -6956,8 +7083,9 @@ pub mod tak_packet {
 }
 ///
 /// ATAK GeoChat message
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -6978,8 +7106,9 @@ pub struct GeoChat {
 ///
 /// ATAK Group
 /// <__group role='Team Member' name='Cyan'/>
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -6997,8 +7126,9 @@ pub struct Group {
 ///
 /// ATAK EUD Status
 /// <status battery='100' />
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -7011,8 +7141,9 @@ pub struct Status {
 ///
 /// ATAK Contact
 /// <contact endpoint='0.0.0.0:4242:tcp' phone='+12345678' callsign='FALKE'/>
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -7031,8 +7162,9 @@ pub struct Contact {
 }
 ///
 /// Position Location Information from ATAK
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -7060,8 +7192,9 @@ pub struct Pli {
     #[prost(uint32, tag = "5")]
     pub course: u32,
 }
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -7161,8 +7294,9 @@ impl Team {
 }
 ///
 /// Role of the group member
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -7232,8 +7366,9 @@ impl MemberRole {
 }
 ///
 /// Canned message module configuration.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -7243,8 +7378,9 @@ pub struct CannedMessageModuleConfig {
     #[prost(string, tag = "1")]
     pub messages: ::prost::alloc::string::String,
 }
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -7288,8 +7424,9 @@ pub struct LocalConfig {
     #[prost(message, optional, tag = "9")]
     pub security: ::core::option::Option<config::SecurityConfig>,
 }
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -7358,8 +7495,9 @@ pub struct LocalModuleConfig {
 ///
 /// This abstraction is used to contain any configuration for provisioning a node on any client.
 /// It is useful for importing and exporting configurations.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -7399,8 +7537,9 @@ pub struct DeviceProfile {
 }
 ///
 /// Position with static location information only for NodeDBLite
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -7431,8 +7570,9 @@ pub struct PositionLite {
     #[prost(enumeration = "position::LocSource", tag = "5")]
     pub location_source: i32,
 }
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -7474,8 +7614,9 @@ pub struct UserLite {
     #[prost(bytes = "vec", tag = "7")]
     pub public_key: ::prost::alloc::vec::Vec<u8>,
 }
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -7539,8 +7680,9 @@ pub struct NodeInfoLite {
 /// FIXME, since we write this each time we enter deep sleep (and have infinite
 /// flash) it would be better to use some sort of append only data structure for
 /// the receive queue and use the preferences store for the other stuff
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -7599,8 +7741,9 @@ pub struct DeviceState {
 }
 ///
 /// The on-disk saved channels
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -7618,8 +7761,9 @@ pub struct ChannelFile {
 }
 ///
 /// This message wraps a MeshPacket with extra metadata about the sender and how it arrived.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -7641,8 +7785,9 @@ pub struct ServiceEnvelope {
 }
 ///
 /// Information about a node intended to be reported unencrypted to a map using MQTT.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -7704,8 +7849,9 @@ pub struct MapReport {
 }
 ///
 /// TODO: REPLACE
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -7725,8 +7871,9 @@ pub struct Paxcount {
 }
 /// Note: There are no 'PowerMon' messages normally in use (PowerMons are sent only as structured logs - slogs).
 /// But we wrap our State enum in this message to effectively nest a namespace (without our linter yelling at us)
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -7735,8 +7882,9 @@ pub struct PowerMon {}
 pub mod power_mon {
     /// Any significant power changing event in meshtastic should be tagged with a powermon state transition.
     /// If you are making new meshtastic features feel free to add new entries at the end of this definition.
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(
@@ -7823,8 +7971,9 @@ pub mod power_mon {
 }
 ///
 /// PowerStress testing support via the C++ PowerStress module
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -7842,8 +7991,9 @@ pub mod power_stress_message {
     /// What operation would we like the UUT to perform.
     /// note: senders should probably set want_response in their request packets, so that they can know when the state
     /// machine has started processing their request
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(
@@ -7968,8 +8118,9 @@ pub mod power_stress_message {
 /// because no security yet (beyond the channel mechanism).
 /// It should be off by default and then protected based on some TBD mechanism
 /// (a special channel once multichannel support is included?)
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -7992,8 +8143,9 @@ pub struct HardwareMessage {
 pub mod hardware_message {
     ///
     /// TODO: REPLACE
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(
@@ -8061,8 +8213,9 @@ pub mod hardware_message {
 }
 ///
 /// Canned message module configuration.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -8074,8 +8227,9 @@ pub struct RtttlConfig {
 }
 ///
 /// TODO: REPLACE
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[allow(clippy::doc_lazy_continuation)]
 #[allow(clippy::empty_docs)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -8093,8 +8247,9 @@ pub struct StoreAndForward {
 pub mod store_and_forward {
     ///
     /// TODO: REPLACE
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -8138,8 +8293,9 @@ pub mod store_and_forward {
     }
     ///
     /// TODO: REPLACE
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -8160,8 +8316,9 @@ pub mod store_and_forward {
     }
     ///
     /// TODO: REPLACE
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -8178,8 +8335,9 @@ pub mod store_and_forward {
     ///
     /// 001 - 063 = From Router
     /// 064 - 127 = From Client
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(
@@ -8296,8 +8454,9 @@ pub mod store_and_forward {
     }
     ///
     /// TODO: REPLACE
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[allow(clippy::doc_lazy_continuation)]
     #[allow(clippy::empty_docs)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,10 @@ pub mod packet {
 pub mod protobufs {
     #![allow(missing_docs)]
     #![allow(non_snake_case)]
+    #![allow(unknown_lints)]
+    #![allow(clippy::empty_docs)]
+    #![allow(clippy::doc_lazy_continuation)]
+    #![allow(clippy::doc_overindented_list_items)]
     include!("generated/meshtastic.rs");
 }
 


### PR DESCRIPTION
- Make generated `meshtastic.rs` the same for `ts-gen` and `serde` features. Fixes https://github.com/meshtastic/rust/issues/53.
- Apply clippy directives to whole generated file `meshtastric.rs` instead of per-struct approach.

