### PR TITLE
Pin bluez-async to 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ gen = ["dep:prost-build", "dep:protoc-bin-vendored", "dep:walkdir"]
 
 serde = ["dep:serde", "dep:serde_json"]
 ts-gen = ["gen", "serde", "dep:specta"]
-bluetooth-le = ["dep:uuid", "dep:btleplug", "dep:futures"]
+bluetooth-le = ["dep:uuid", "dep:btleplug", "dep:futures", "dep:bluez-async"]
 
 [lints.rust]
 missing_docs = "warn"
@@ -64,6 +64,12 @@ thiserror = "2.0.11"
 uuid = { version = "1.12.1", optional = true }
 btleplug = { version = "0.11.7", optional = true }
 futures = { version = "0.3.31", optional = true }
+
+#TODO: drop pinning of the bluez-async version once we move the MSRV to 1.84 and we can use
+#MSRV-aware resolver instead of this hack. See
+#https://blog.rust-lang.org/2025/01/09/Rust-1.84.0/#cargo-considers-rust-versions-for-dependency-version-selection
+[target.'cfg(target_os = "linux")'.dependencies]
+bluez-async = { version = "=0.8.0", optional = true }
 
 [dev-dependencies]
 fern = { version = "0.7.1", features = ["colored"] }


### PR DESCRIPTION
**Summary**
bluez-async 0.8.1 requires 2024 edition which we don't support yet, we are at MSRV 1.76. We pin it at an older version still using 2021.

**Related Issues**


**Proposed Changes**
-  pin bluez-async to 0.8.0

**Checklist**
- [x] Tests pass locally
- [x] Documentation updated if needed
