### PR TITLE
Gate Tokio features behind a `tokio` flag (enabled by default).

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,7 +26,7 @@ jobs:
       - name: cargo check
         run: cargo check ${{ matrix.features }}
       - name: cargo fmt
-        run: cargo fmt --all -- --check ${{ matrix.features }}
+        run: cargo fmt --all -- --check
       - name: cargo clippy
         run: |
           rustup override set 1.80

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -6,6 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
+        features: ["--all-features", "--no-default-features"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -23,13 +24,13 @@ jobs:
           rustup override set 1.76
           rustup component add rustfmt
       - name: cargo check
-        run: cargo check
+        run: cargo check ${{ matrix.features }}
       - name: cargo fmt
-        run: cargo fmt --all -- --check
+        run: cargo fmt --all -- --check ${{ matrix.features }}
       - name: cargo clippy
         run: |
           rustup override set 1.80
           rustup component add clippy
-          cargo clippy -- -D warnings
+          cargo clippy -- -D warnings ${{ matrix.features }}
       - name: cargo test
-        run: cargo +1.76.0 test --all-features
+        run: cargo +1.76.0 test ${{ matrix.features }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -31,6 +31,6 @@ jobs:
         run: |
           rustup override set 1.80
           rustup component add clippy
-          cargo clippy -- -D warnings ${{ matrix.features }}
+          cargo clippy -- -D warnings
       - name: cargo test
         run: cargo +1.76.0 test ${{ matrix.features }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,20 +29,23 @@ missing_docs = "warn"
 
 [[example]]
 name = "basic_serial"
+required-features = ["tokio"]
 
 [[example]]
 name = "basic_tcp"
+required-features = ["tokio"]
 
 [[example]]
 name = "message_filtering"
+required-features = ["tokio"]
 
 [[example]]
 name = "generate_typescript_types"
-required-features = ["ts-gen"]
+required-features = ["ts-gen", "tokio"]
 
 [[example]]
 name = "basic_ble"
-required-features = ["bluetooth-le"]
+required-features = ["bluetooth-le", "tokio"]
 
 [build-dependencies]
 prost-build = { version = "0.14", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,13 @@ edition = "2021"
 doctest = false
 
 [features]
-default = ["serde"]
+default = ["serde", "tokio"]
 gen = ["dep:prost-build", "dep:protoc-bin-vendored", "dep:walkdir"]
 
 serde = ["dep:serde", "dep:serde_json"]
 ts-gen = ["gen", "serde", "dep:specta"]
 bluetooth-le = ["dep:uuid", "dep:btleplug", "dep:futures", "dep:bluez-async"]
+tokio = ["dep:tokio", "dep:tokio-serial", "dep:tokio-util"]
 
 [lints.rust]
 missing_docs = "warn"
@@ -51,13 +52,15 @@ walkdir = { version = "2.5.0", optional = true }
 [dependencies]
 futures-util = "0.3.31"
 rand = "0.9.0"
-tokio = { version = "1.43.0", features = ["full"] }
-tokio-serial = "5.4.5"
-tokio-util = "0.7.13"
+tokio = { version = "1.43.0", features = ["full"], optional = true }
+tokio-serial = { version = "5.4.5", optional = true }
+tokio-util = { version = "0.7.13", optional = true }
 prost = "0.14"
 log = "0.4.25"
 
-specta = { git = "https://github.com/ajmcquilkin/specta.git", rev = "6a8731d", optional = true, features = ["chrono"], version = "=1.0.3" }
+specta = { git = "https://github.com/ajmcquilkin/specta.git", rev = "6a8731d", optional = true, features = [
+    "chrono",
+], version = "=1.0.3" }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 thiserror = "2.0.11"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 //! A Rust library for communicating with and configuring Meshtastic devices.
+#[cfg(feature = "tokio")]
 pub(crate) mod connections;
+#[cfg(feature = "tokio")]
 pub(crate) mod errors_internal;
+#[cfg(feature = "tokio")]
 pub(crate) mod utils_internal;
 
 /// A re-export of the `prost::Message` trait, which is required to call the `encode`
@@ -27,6 +30,7 @@ pub use prost::Message;
 /// to the full set of API sender methods.
 ///
 /// To disconnect from the radio, the user can call the `disconnect` method at any time.
+#[cfg(feature = "tokio")]
 pub mod api {
     pub use crate::connections::stream_api::state;
     pub use crate::connections::stream_api::ConnectedStreamApi;
@@ -37,6 +41,7 @@ pub mod api {
 /// This module contains the global `Error` type of the library. This enum implements
 /// `std::error::Error`, `std::fmt::Display`, and `std::fmt::Debug`. This enum is used to
 /// represent all errors that can occur within the library.
+#[cfg(feature = "tokio")]
 pub mod errors {
     pub use crate::errors_internal::Error;
 }
@@ -61,6 +66,7 @@ pub mod errors {
 ///
 /// The `PacketReceiver` type defines the type of the tokio channel that is used to receive decoded packets from the radio.
 /// This is intended to simplify the complexity of the underlying channel type.
+#[cfg(feature = "tokio")]
 pub mod packet {
     pub use crate::connections::handlers::CLIENT_HEARTBEAT_INTERVAL;
     pub use crate::connections::PacketDestination;
@@ -112,6 +118,7 @@ pub mod ts {
 /// These methods are intended for use by more advanced users.
 ///
 /// The `stream` module contains helper methods that are used to build connection stream instances.
+#[cfg(feature = "tokio")]
 pub mod utils {
     pub use crate::utils_internal::DEFAULT_DTR_PIN_STATE;
     pub use crate::utils_internal::DEFAULT_RTS_PIN_STATE;
@@ -165,6 +172,7 @@ pub mod utils {
 /// The `EncodedToRadioPacketWithHeader` struct is a wrapper around a `Vec<u8>` value that
 /// represents the payload data of a packet that is intended to be sent to the radio. This
 /// struct includes the required packet header, and can be sent to the radio.
+#[cfg(feature = "tokio")]
 pub mod types {
     pub use crate::connections::wrappers::encoded_data::EncodedMeshPacketData;
     pub use crate::connections::wrappers::encoded_data::EncodedToRadioPacket;


### PR DESCRIPTION
This evening I wrote this:

https://frewsxcv.github.io/meshtastic-config-reader/

https://github.com/frewsxcv/meshtastic-config-reader

Which is a simple tool for reading exported Meshtastic device configuration files. In order to do this, I need the Rust bindings for the Meshtastic protobufs, which this crate offers. Because Tokio support with WASM is not straightforward, and I don't need any of that functionality for this project (I just need `meshtastic::protobufs`), I gated all the Tokio functionality behind a `tokio` feature flag. This allows me to disable that dependency tree.

Because the new `tokio` feature is enabled by default, this shouldn't be a breaking change.