### PR TITLE
Bump MSRV to 1.84

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,7 +21,7 @@ jobs:
           sudo apt-get install -y libdbus-1-dev
       - name: Set toolchain version
         run: |
-          rustup override set 1.76
+          rustup override set 1.84
           rustup component add rustfmt
       - name: cargo check
         run: cargo check ${{ matrix.features }}
@@ -29,8 +29,7 @@ jobs:
         run: cargo fmt --all -- --check
       - name: cargo clippy
         run: |
-          rustup override set 1.80
           rustup component add clippy
           cargo clippy -- -D warnings
       - name: cargo test
-        run: cargo +1.76.0 test ${{ matrix.features }}
+        run: cargo test ${{ matrix.features }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["Adam McQuilkin"]
 readme = "README.md"
 license = "GPL-3.0"
 version = "0.1.7"
-rust-version = "1.76"
+rust-version = "1.84"
 edition = "2021"
 
 [lib]
@@ -54,8 +54,6 @@ walkdir = { version = "2.5.0", optional = true }
 
 [dependencies]
 futures-util = "0.3.31"
-#TODO: remove indexmap after moving to rust 1.84+. It's listed here only to lock the version.
-indexmap = "=2.11.0"
 rand = "0.9.0"
 tokio = { version = "1.43.0", features = ["full"], optional = true }
 tokio-serial = { version = "5.4.5", optional = true }


### PR DESCRIPTION
**Summary**
Rust 1.84 brings a MSRV-aware resolver which discards dependencies which require a too new toolchain.

Thus we cand drop the pinned version of indexmap, the resolver will do its job.

**Related Issues**
#46

**Proposed Changes**
- Bump MSRV to 1.84
- Drop `indexmap` dependency

**Checklist**
- [x] Tests pass locally