### PR TITLE
Add serialization/deserialization for BleDevice

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 thiserror = "2.0.11"
 uuid = { version = "1.12.1", optional = true }
-btleplug = { version = "0.11.7", optional = true }
+btleplug = { version = "0.11.7", optional = true, features = ["serde"] }
 futures = { version = "0.3.31", optional = true }
 
 #TODO: drop pinning of the bluez-async version once we move the MSRV to 1.84 and we can use

--- a/src/connections/ble_handler.rs
+++ b/src/connections/ble_handler.rs
@@ -6,6 +6,7 @@ use btleplug::platform::{Adapter, Manager, Peripheral};
 use futures::stream::StreamExt;
 use futures_util::stream::BoxStream;
 use log::error;
+use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use std::future;
 use std::str::FromStr;
@@ -87,7 +88,7 @@ impl Display for BleId {
 }
 
 /// A Meshtastic device discovered via Bluetooth LE.
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct BleDevice {
     /// The broadcast name of the device.
     pub name: Option<String>,


### PR DESCRIPTION
**Summary**
Serialization/deserialization for `BleDevice` is easy to do once btleplug is compiled with the `serde` feature.

**Related Issues**
Fixes #73 

**Checklist**
- [x] Tests pass locally
- [x] Documentation updated if needed
