### PR TITLE
Improve usability of `build_ble_stream()`

### DIFF
--- a/src/errors_internal.rs
+++ b/src/errors_internal.rs
@@ -70,6 +70,11 @@ pub enum Error {
     /// An error indicating that the library failed when performing an operation on an internal data channel.
     #[error(transparent)]
     InternalChannelError(#[from] InternalChannelError),
+
+    /// An error indicating MAC address parse error
+    #[cfg(feature = "bluetooth-le")]
+    #[error(transparent)]
+    MacAddressParseError(#[from] btleplug::api::ParseBDAddrError),
 }
 
 /// An enum that defines the possible internal errors that can occur within the library when handling streams.


### PR DESCRIPTION
**Summary**
Accept `Cow<a, BleId>` instead of `BleId` as the first parameter of `build_ble_stream()`. This allows passing of all:
* BleId and &BleId
* BleDevice and &BleDevice


**Related Issues**
N/A

**Checklist**
- [x] Tests pass locally
- [x] Documentation updated if needed
