### PR TITLE
Clarify the use of the "to" field of MeshPacket struct

### DIFF
--- a/src/generated/meshtastic.rs
+++ b/src/generated/meshtastic.rs
@@ -5111,7 +5111,11 @@ pub struct MeshPacket {
     #[prost(fixed32, tag = "1")]
     pub from: u32,
     ///
-    /// The (immediate) destination for this packet
+    /// The (immediate) destination for this packet.
+    /// If the value is u32::MAX, this indicates that the packet was not destined for a specific
+    /// node, but for a channel as indicated by the value of `channel` below.
+    /// If the value is not u32MAX, this indicates that the packet was destined for a specific
+    /// node (i.e. a kind of "Direct Message" to this node) and not broadcast on a channel.
     #[prost(fixed32, tag = "2")]
     pub to: u32,
     ///


### PR DESCRIPTION
**Summary**
Clarify the use of the "to" field of MeshPacket struct, and how to use it to determine if a packet was sent to a node or to a channel

**Related Issues**
Links (e.g. closes #123).

**Proposed Changes**
-  the doc comment on "to" field
-

**Checklist**
- [ ] Tests pass locally
- [X] Documentation updated if needed
