### PR TITLE
Echo on success

### DIFF
--- a/src/connections/stream_api.rs
+++ b/src/connections/stream_api.rs
@@ -212,16 +212,18 @@ impl<State> ConnectedStreamApi<State> {
 
         mesh_packet.rx_time = current_epoch_secs_u32();
 
-        let payload_variant = Some(protobufs::to_radio::PayloadVariant::Packet(mesh_packet.clone()));
+        let payload_variant = Some(protobufs::to_radio::PayloadVariant::Packet(
+            mesh_packet.clone(),
+        ));
         self.send_to_radio_packet(payload_variant).await?;
 
         // If the sending was successful, echo it back to the client via the `PacketRouter`
         if echo_response {
-            packet_router
-                .handle_mesh_packet(mesh_packet)
-                .map_err(|e| Error::PacketHandlerFailure {
+            packet_router.handle_mesh_packet(mesh_packet).map_err(|e| {
+                Error::PacketHandlerFailure {
                     source: Box::new(e),
-                })?;
+                }
+            })?;
         }
 
         Ok(())


### PR DESCRIPTION
**Summary**
Currently a mesh packet attempting to be sent is echoed back to the client via the Packet Router, before attempting to send. So, if sending fails, it will appear to the router as if it worked when in fact it failed.

This change only echos back via the router if the sending was successful

**Related Issues**


**Proposed Changes**
-  Move the section of code that echos back the packet via router to after the call to send (DONE)
-

**Checklist**
- [X] Tests pass locally
- [ ] Documentation updated if needed
