### PR TITLE
Bump MSRV to 1.85

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,7 +21,7 @@ jobs:
           sudo apt-get install -y libdbus-1-dev
       - name: Set toolchain version
         run: |
-          rustup override set 1.84
+          rustup override set 1.85
           rustup component add rustfmt
       - name: cargo check
         run: cargo check ${{ matrix.features }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Adam McQuilkin"]
 readme = "README.md"
 license = "GPL-3.0"
 version = "0.1.8"
-rust-version = "1.84"
+rust-version = "1.85"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
**Summary**
This should fix build issues with new dependencies using 2024 edition. Note that we are not switching to 2024 edition yet.

**Related Issues**
#92 

**Proposed Changes**
-  Bump MSRV to 1.85

**Checklist**
- [x] Tests pass locally
- [x] Documentation updated if needed
