### PR TITLE
added `strum` feature (iter enum variants)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,14 @@ edition = "2021"
 doctest = false
 
 [features]
-default = ["serde", "tokio"]
+default = ["serde", "tokio", "strum"]
 gen = ["dep:prost-build", "dep:protoc-bin-vendored", "dep:walkdir"]
 
 serde = ["dep:serde", "dep:serde_json"]
 ts-gen = ["serde", "dep:specta", "dep:specta-typescript"]
 bluetooth-le = ["dep:uuid", "dep:btleplug", "dep:futures", "dep:bluez-async"]
 tokio = ["dep:tokio", "dep:tokio-serial", "dep:tokio-util"]
+strum = ["dep:strum"]
 
 [lints.rust]
 missing_docs = "warn"
@@ -74,6 +75,7 @@ thiserror = "2.0.11"
 uuid = { version = "1.12.1", optional = true }
 btleplug = { version = "0.11.7", optional = true, features = ["serde"] }
 futures = { version = "0.3.31", optional = true }
+strum = { version = "0.28", optional = true, features = ["derive"] }
 
 #TODO: drop pinning of the bluez-async version once we move the MSRV to 1.84 and we can use
 #MSRV-aware resolver instead of this hack. See

--- a/build.rs
+++ b/build.rs
@@ -47,6 +47,10 @@ fn main() -> std::io::Result<()> {
         ".",
         "#[cfg_attr(feature = \"ts-gen\", derive(specta::Type))]",
     );
+    config.enum_attribute(
+        ".",
+        "#[cfg_attr(feature = \"strum\", derive(strum::EnumCount, strum::EnumIter))]",
+    );
 
     config.out_dir(gen_dir);
     config.compile_protos(&protos, &[src_dir])

--- a/src/generated/meshtastic.rs
+++ b/src/generated/meshtastic.rs
@@ -130,6 +130,7 @@ pub mod channel {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
         Clone,
         Copy,
@@ -260,6 +261,7 @@ pub mod device_ui_config {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
         Clone,
         Copy,
@@ -433,6 +435,7 @@ pub struct Map {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+#[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum CompassMode {
@@ -471,6 +474,7 @@ impl CompassMode {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+#[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum Theme {
@@ -511,6 +515,7 @@ impl Theme {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+#[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum Language {
@@ -725,6 +730,7 @@ pub mod config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+        #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
             Clone,
             Copy,
@@ -860,6 +866,7 @@ pub mod config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+        #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
             Clone,
             Copy,
@@ -930,6 +937,7 @@ pub mod config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+        #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
             Clone,
             Copy,
@@ -1073,6 +1081,7 @@ pub mod config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+        #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
             Clone,
             Copy,
@@ -1165,6 +1174,7 @@ pub mod config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+        #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
             Clone,
             Copy,
@@ -1344,6 +1354,7 @@ pub mod config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+        #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
             Clone,
             Copy,
@@ -1389,6 +1400,7 @@ pub mod config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+        #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
             Clone,
             Copy,
@@ -1512,6 +1524,7 @@ pub mod config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+        #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
             Clone,
             Copy,
@@ -1550,6 +1563,7 @@ pub mod config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+        #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
             Clone,
             Copy,
@@ -1595,6 +1609,7 @@ pub mod config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+        #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
             Clone,
             Copy,
@@ -1653,6 +1668,7 @@ pub mod config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+        #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
             Clone,
             Copy,
@@ -1706,6 +1722,7 @@ pub mod config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+        #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
             Clone,
             Copy,
@@ -1893,6 +1910,7 @@ pub mod config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+        #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
             Clone,
             Copy,
@@ -2064,6 +2082,7 @@ pub mod config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+        #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
             Clone,
             Copy,
@@ -2177,6 +2196,7 @@ pub mod config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+        #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
             Clone,
             Copy,
@@ -2273,6 +2293,7 @@ pub mod config {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum PayloadVariant {
         #[prost(message, tag = "1")]
@@ -2605,6 +2626,7 @@ pub mod module_config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+        #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
             Clone,
             Copy,
@@ -2705,6 +2727,7 @@ pub mod module_config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+        #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
             Clone,
             Copy,
@@ -2899,6 +2922,7 @@ pub mod module_config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+        #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
             Clone,
             Copy,
@@ -2982,6 +3006,7 @@ pub mod module_config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+        #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
             Clone,
             Copy,
@@ -3330,6 +3355,7 @@ pub mod module_config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+        #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
             Clone,
             Copy,
@@ -3447,6 +3473,7 @@ pub mod module_config {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum PayloadVariant {
         ///
@@ -3534,6 +3561,7 @@ pub struct RemoteHardwarePin {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+#[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum RemoteHardwarePinType {
@@ -3585,6 +3613,7 @@ impl RemoteHardwarePinType {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+#[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum PortNum {
@@ -4336,6 +4365,7 @@ pub mod telemetry {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Variant {
         ///
@@ -4425,6 +4455,7 @@ pub struct Sen5xState {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+#[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum TelemetrySensorType {
@@ -4709,6 +4740,7 @@ pub mod x_modem {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
         Clone,
         Copy,
@@ -4890,6 +4922,7 @@ pub mod position {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
         Clone,
         Copy,
@@ -4946,6 +4979,7 @@ pub mod position {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
         Clone,
         Copy,
@@ -5120,6 +5154,7 @@ pub mod routing {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
         Clone,
         Copy,
@@ -5247,6 +5282,7 @@ pub mod routing {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
     pub enum Variant {
         ///
@@ -5396,6 +5432,7 @@ pub mod store_forward_plus_plus {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
         Clone,
         Copy,
@@ -5537,6 +5574,7 @@ pub mod mqtt_client_proxy_message {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
     pub enum PayloadVariant {
         ///
@@ -5703,6 +5741,7 @@ pub mod mesh_packet {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
         Clone,
         Copy,
@@ -5792,6 +5831,7 @@ pub mod mesh_packet {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
         Clone,
         Copy,
@@ -5842,6 +5882,7 @@ pub mod mesh_packet {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
         Clone,
         Copy,
@@ -5915,6 +5956,7 @@ pub mod mesh_packet {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
     pub enum PayloadVariant {
         ///
@@ -6086,6 +6128,7 @@ pub mod log_record {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
         Clone,
         Copy,
@@ -6200,6 +6243,7 @@ pub mod from_radio {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum PayloadVariant {
         ///
@@ -6310,6 +6354,7 @@ pub mod client_notification {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
     pub enum PayloadVariant {
         #[prost(message, tag = "11")]
@@ -6406,6 +6451,7 @@ pub mod to_radio {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum PayloadVariant {
         ///
@@ -6646,6 +6692,7 @@ pub mod chunked_payload_response {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
     pub enum PayloadVariant {
         ///
@@ -6670,6 +6717,7 @@ pub mod chunked_payload_response {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+#[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum HardwareModel {
@@ -7349,6 +7397,7 @@ impl HardwareModel {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+#[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum Constants {
@@ -7390,6 +7439,7 @@ impl Constants {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+#[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum CriticalErrorCode {
@@ -7491,6 +7541,7 @@ impl CriticalErrorCode {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+#[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum FirmwareEdition {
@@ -7553,6 +7604,7 @@ impl FirmwareEdition {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+#[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum ExcludedModules {
@@ -7725,6 +7777,7 @@ pub mod admin_message {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
         Clone,
         Copy,
@@ -7810,6 +7863,7 @@ pub mod admin_message {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
         Clone,
         Copy,
@@ -7918,6 +7972,7 @@ pub mod admin_message {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
         Clone,
         Copy,
@@ -7963,6 +8018,7 @@ pub mod admin_message {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum PayloadVariant {
         ///
@@ -8298,6 +8354,7 @@ pub mod key_verification_admin {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
         Clone,
         Copy,
@@ -8417,6 +8474,7 @@ pub struct Sen5xConfig {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+#[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum OtaMode {
@@ -8507,6 +8565,7 @@ pub mod tak_packet {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
     pub enum PayloadVariant {
         ///
@@ -8628,6 +8687,7 @@ pub struct Pli {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+#[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum Team {
@@ -8728,6 +8788,7 @@ impl Team {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+#[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum MemberRole {
@@ -9252,6 +9313,7 @@ pub mod sensor_data {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(Clone, Copy, PartialEq, ::prost::Oneof)]
     pub enum Data {
         #[prost(float, tag = "2")]
@@ -9275,6 +9337,7 @@ pub mod interdevice_message {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Data {
         #[prost(string, tag = "1")]
@@ -9286,6 +9349,7 @@ pub mod interdevice_message {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+#[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum MessageType {
@@ -9468,6 +9532,7 @@ pub mod power_mon {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
         Clone,
         Copy,
@@ -9573,6 +9638,7 @@ pub mod power_stress_message {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
         Clone,
         Copy,
@@ -9721,6 +9787,7 @@ pub mod hardware_message {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
         Clone,
         Copy,
@@ -9901,6 +9968,7 @@ pub mod store_and_forward {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
         Clone,
         Copy,
@@ -10018,6 +10086,7 @@ pub mod store_and_forward {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
+    #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
     pub enum Variant {
         ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,7 @@ pub mod protobufs {
     #![allow(missing_docs)]
     #![allow(non_snake_case)]
     #![allow(unknown_lints)]
+    #![allow(deprecated)]
     #![allow(clippy::empty_docs)]
     #![allow(clippy::doc_lazy_continuation)]
     #![allow(clippy::doc_overindented_list_items)]


### PR DESCRIPTION
**Summary**
Added `strum::EnumCount` and `strum::EnumIter` derives to all generated enums. It allows you to iterate over enum variants and obtain the total variants count. It will be very useful for Meshtastic client makers (like me xD), for example, you can fetch any enum variants and use it to render dropdowns.

**Related Issues**
- no related issues

**Proposed Changes**
- Added `strum` optional dependency
- Added `strum` feature to default features
- Changed `build.rs`: Configured `prost_build` to add attribute to the enums
- Regenerated `meshtastic.rs`

**Checklist**
- [x] Tests pass locally
- [x] Documentation updated if needed (dunno where to write my changes, they are very niche)
