### PR TITLE
Remove bluez-async dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ license = "GPL-3.0"
 version = "0.1.8"
 rust-version = "1.85"
 edition = "2021"
+resolver = "3"
 
 [lib]
 doctest = false
@@ -22,7 +23,7 @@ gen = ["dep:prost-build", "dep:protoc-bin-vendored", "dep:walkdir"]
 
 serde = ["dep:serde", "dep:serde_json"]
 ts-gen = ["serde", "dep:specta", "dep:specta-typescript"]
-bluetooth-le = ["dep:uuid", "dep:btleplug", "dep:futures", "dep:bluez-async"]
+bluetooth-le = ["dep:uuid", "dep:btleplug", "dep:futures"]
 tokio = ["dep:tokio", "dep:tokio-serial", "dep:tokio-util"]
 strum = ["dep:strum"]
 
@@ -76,12 +77,6 @@ uuid = { version = "1.12.1", optional = true }
 btleplug = { version = "0.11.7", optional = true, features = ["serde"] }
 futures = { version = "0.3.31", optional = true }
 strum = { version = "0.28", optional = true, features = ["derive"] }
-
-#TODO: drop pinning of the bluez-async version once we move the MSRV to 1.84 and we can use
-#MSRV-aware resolver instead of this hack. See
-#https://blog.rust-lang.org/2025/01/09/Rust-1.84.0/#cargo-considers-rust-versions-for-dependency-version-selection
-[target.'cfg(target_os = "linux")'.dependencies]
-bluez-async = { version = "=0.8.0", optional = true }
 
 [dev-dependencies]
 fern = { version = "0.7.1", features = ["colored"] }


### PR DESCRIPTION
**Summary**
Not needed after updated MSRV

**Related Issues**
#93 

**Proposed Changes**
Remove bluez-async dependency

**Checklist**
- [x] Tests pass locally
- [x] Documentation updated if needed
