### PR TITLE
Update btleplug version to 0.12.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 thiserror = "2.0.11"
 uuid = { version = "1.12.1", optional = true }
-btleplug = { version = "0.11.7", optional = true, features = ["serde"] }
+btleplug = { version = "0.12.0", optional = true, features = ["serde"] }
 futures = { version = "0.3.31", optional = true }
 strum = { version = "0.28", optional = true, features = ["derive"] }
 


### PR DESCRIPTION
Keep with the latest and allow dependents of this crate to use btleplug 0.12.0 too

**Summary**
Move to btleplug 0.12.0

**Related Issues**

**Proposed Changes**
-

**Checklist**
