### PR TITLE
Enabled `echo_response` for all methods + `serde(rename_all = "snake_case")`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -41,7 +41,7 @@ fn main() -> std::io::Result<()> {
     );
     config.type_attribute(
         ".",
-        "#[cfg_attr(feature = \"serde\", serde(rename_all = \"camelCase\"))]",
+        "#[cfg_attr(feature = \"serde\", serde(rename_all = \"snake_case\"))]",
     );
     config.type_attribute(
         ".",

--- a/src/connections/stream_api.rs
+++ b/src/connections/stream_api.rs
@@ -905,7 +905,7 @@ impl ConnectedStreamApi<state::Configured> {
             MeshChannel::new(0)?,
             true,
             true,
-            false,
+            true,
             None,
             None,
         )
@@ -982,7 +982,7 @@ impl ConnectedStreamApi<state::Configured> {
             MeshChannel::new(0)?,
             true,
             true,
-            false,
+            true,
             None,
             None,
         )
@@ -1059,7 +1059,7 @@ impl ConnectedStreamApi<state::Configured> {
             MeshChannel::new(0)?,
             true,
             true,
-            false,
+            true,
             None,
             None,
         )
@@ -1127,7 +1127,7 @@ impl ConnectedStreamApi<state::Configured> {
             MeshChannel::new(0)?,
             true,
             true,
-            false,
+            true,
             None,
             None,
         )

--- a/src/generated/meshtastic.rs
+++ b/src/generated/meshtastic.rs
@@ -16,7 +16,7 @@
 /// FIXME: explain how apps use channels for security.
 /// explain how remote settings and remote gpio are managed as an example
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ChannelSettings {
@@ -79,7 +79,7 @@ pub struct ChannelSettings {
 ///
 /// This message is specifically for modules to store per-channel configuration data.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ModuleSettings {
@@ -96,7 +96,7 @@ pub struct ModuleSettings {
 ///
 /// A pair of a channel number, mode and the (sharable) settings for that channel
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Channel {
@@ -128,7 +128,7 @@ pub mod channel {
     /// If a device has only a single radio (the common case) only one channel can be PRIMARY at a time
     /// (but any number of SECONDARY channels can't be sent received on that common frequency)
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
@@ -179,7 +179,7 @@ pub mod channel {
     }
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct DeviceUiConfig {
@@ -259,7 +259,7 @@ pub mod device_ui_config {
     ///
     /// How the GPS coordinates are displayed on the OLED screen.
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
@@ -337,7 +337,7 @@ pub mod device_ui_config {
     }
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct NodeFilter {
@@ -371,7 +371,7 @@ pub struct NodeFilter {
     pub channel: i32,
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct NodeHighlight {
@@ -397,7 +397,7 @@ pub struct NodeHighlight {
     pub node_name: ::prost::alloc::string::String,
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GeoPoint {
@@ -415,7 +415,7 @@ pub struct GeoPoint {
     pub longitude: i32,
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Map {
@@ -433,7 +433,7 @@ pub struct Map {
     pub follow_gps: bool,
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -472,7 +472,7 @@ impl CompassMode {
     }
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -513,7 +513,7 @@ impl Theme {
 ///
 /// Localization
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -647,7 +647,7 @@ impl Language {
     }
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Config {
@@ -661,7 +661,7 @@ pub mod config {
     ///
     /// Configuration
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct DeviceConfig {
@@ -728,7 +728,7 @@ pub mod config {
         ///
         /// Defines the device's role on the Mesh network
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
@@ -864,7 +864,7 @@ pub mod config {
         ///
         /// Defines the device's behavior for how messages are rebroadcast
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
@@ -935,7 +935,7 @@ pub mod config {
         ///
         /// Defines buzzer behavior for audio feedback
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
@@ -1004,7 +1004,7 @@ pub mod config {
     ///
     /// Position Config
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct PositionConfig {
@@ -1079,7 +1079,7 @@ pub mod config {
         /// NOTE: the more fields are included, the larger the message will be -
         ///    leading to longer airtime and a higher risk of packet loss
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
@@ -1172,7 +1172,7 @@ pub mod config {
             }
         }
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
@@ -1225,7 +1225,7 @@ pub mod config {
     /// Power Config\
     /// See [Power Config](/docs/settings/config/power) for additional power config details.
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
     pub struct PowerConfig {
@@ -1281,7 +1281,7 @@ pub mod config {
     ///
     /// Network Config
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct NetworkConfig {
@@ -1330,7 +1330,7 @@ pub mod config {
     /// Nested message and enum types in `NetworkConfig`.
     pub mod network_config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
         pub struct IpV4Config {
@@ -1352,7 +1352,7 @@ pub mod config {
             pub dns: u32,
         }
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
@@ -1398,7 +1398,7 @@ pub mod config {
         ///
         /// Available flags auxiliary network protocols
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
@@ -1445,7 +1445,7 @@ pub mod config {
     ///
     /// Display Config
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct DisplayConfig {
@@ -1522,7 +1522,7 @@ pub mod config {
         ///
         /// Deprecated in 2.7.4: Unused
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
@@ -1561,7 +1561,7 @@ pub mod config {
         ///
         /// Unit display preference
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
@@ -1607,7 +1607,7 @@ pub mod config {
         ///
         /// Override OLED outo detect with this if it fails.
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
@@ -1666,7 +1666,7 @@ pub mod config {
             }
         }
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
@@ -1720,7 +1720,7 @@ pub mod config {
             }
         }
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
@@ -1797,7 +1797,7 @@ pub mod config {
     ///
     /// Lora Config
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct LoRaConfig {
@@ -1908,7 +1908,7 @@ pub mod config {
     /// Nested message and enum types in `LoRaConfig`.
     pub mod lo_ra_config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
@@ -2080,7 +2080,7 @@ pub mod config {
         /// Standard predefined channel settings
         /// Note: these mappings must match ModemPreset Choice in the device code.
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
@@ -2174,7 +2174,7 @@ pub mod config {
         }
     }
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct BluetoothConfig {
@@ -2194,7 +2194,7 @@ pub mod config {
     /// Nested message and enum types in `BluetoothConfig`.
     pub mod bluetooth_config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
@@ -2244,7 +2244,7 @@ pub mod config {
         }
     }
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct SecurityConfig {
@@ -2284,14 +2284,14 @@ pub mod config {
     ///
     /// Blank config request, strictly for getting the session key
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct SessionkeyConfig {}
     ///
     /// Payload Variant
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
@@ -2319,7 +2319,7 @@ pub mod config {
     }
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct DeviceConnectionStatus {
@@ -2343,7 +2343,7 @@ pub struct DeviceConnectionStatus {
 ///
 /// WiFi connection status
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct WifiConnectionStatus {
@@ -2363,7 +2363,7 @@ pub struct WifiConnectionStatus {
 ///
 /// Ethernet connection status
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct EthernetConnectionStatus {
@@ -2375,7 +2375,7 @@ pub struct EthernetConnectionStatus {
 ///
 /// Ethernet or WiFi connection status
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct NetworkConnectionStatus {
@@ -2399,7 +2399,7 @@ pub struct NetworkConnectionStatus {
 ///
 /// Bluetooth connection status
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct BluetoothConnectionStatus {
@@ -2419,7 +2419,7 @@ pub struct BluetoothConnectionStatus {
 ///
 /// Serial connection status
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SerialConnectionStatus {
@@ -2435,7 +2435,7 @@ pub struct SerialConnectionStatus {
 ///
 /// Module Config
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ModuleConfig {
@@ -2452,7 +2452,7 @@ pub mod module_config {
     ///
     /// MQTT Client Config
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct MqttConfig {
@@ -2514,7 +2514,7 @@ pub mod module_config {
     ///
     /// Settings for reporting unencrypted information about our node to a map via MQTT
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct MapReportSettings {
@@ -2534,7 +2534,7 @@ pub mod module_config {
     ///
     /// RemoteHardwareModule Config
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct RemoteHardwareConfig {
@@ -2554,7 +2554,7 @@ pub mod module_config {
     ///
     /// NeighborInfoModule Config
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct NeighborInfoConfig {
@@ -2576,7 +2576,7 @@ pub mod module_config {
     ///
     /// Detection Sensor Module Config
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct DetectionSensorConfig {
@@ -2624,7 +2624,7 @@ pub mod module_config {
     /// Nested message and enum types in `DetectionSensorConfig`.
     pub mod detection_sensor_config {
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
@@ -2687,7 +2687,7 @@ pub mod module_config {
     ///
     /// Audio Config for codec2 voice
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct AudioConfig {
@@ -2725,7 +2725,7 @@ pub mod module_config {
         ///
         /// Baudrate for codec2 voice
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
@@ -2789,7 +2789,7 @@ pub mod module_config {
     ///
     /// Config for the Paxcounter Module
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct PaxcounterConfig {
@@ -2812,7 +2812,7 @@ pub mod module_config {
     /// Config for the Traffic Management module.
     /// Provides packet inspection and traffic shaping to help reduce channel utilization
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct TrafficManagementConfig {
@@ -2876,7 +2876,7 @@ pub mod module_config {
     ///
     /// Serial Config
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct SerialConfig {
@@ -2920,7 +2920,7 @@ pub mod module_config {
         ///
         /// TODO: REPLACE
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
@@ -3004,7 +3004,7 @@ pub mod module_config {
         ///
         /// TODO: REPLACE
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
@@ -3084,7 +3084,7 @@ pub mod module_config {
     ///
     /// External Notifications Config
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct ExternalNotificationConfig {
@@ -3163,7 +3163,7 @@ pub mod module_config {
     ///
     /// Store and Forward Module Config
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct StoreForwardConfig {
@@ -3195,7 +3195,7 @@ pub mod module_config {
     ///
     /// Preferences for the RangeTestModule
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct RangeTestConfig {
@@ -3221,7 +3221,7 @@ pub mod module_config {
     ///
     /// Configuration for both device and environment metrics
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct TelemetryConfig {
@@ -3295,7 +3295,7 @@ pub mod module_config {
     ///
     /// Canned Messages Module Config
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct CannedMessageConfig {
@@ -3353,7 +3353,7 @@ pub mod module_config {
         ///
         /// TODO: REPLACE
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
         #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
         #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
         #[derive(
@@ -3431,7 +3431,7 @@ pub mod module_config {
     /// Ambient Lighting Module - Settings for control of onboard LEDs to allow users to adjust the brightness levels and respective color levels.
     /// Initially created for the RAK14001 RGB LED module.
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct AmbientLightingConfig {
@@ -3459,7 +3459,7 @@ pub mod module_config {
     ///
     /// StatusMessage config - Allows setting a status message for a node to periodically rebroadcast
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct StatusMessageConfig {
@@ -3471,7 +3471,7 @@ pub mod module_config {
     ///
     /// TODO: REPLACE
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
@@ -3541,7 +3541,7 @@ pub mod module_config {
 ///
 /// A GPIO pin definition for remote hardware module
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RemoteHardwarePin {
@@ -3559,7 +3559,7 @@ pub struct RemoteHardwarePin {
     pub r#type: i32,
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -3611,7 +3611,7 @@ impl RemoteHardwarePinType {
 /// We have change to this 'portnum' based scheme for specifying app handlers for particular payloads.
 /// This change is backwards compatible by treating the legacy OPAQUE/CLEAR_TEXT values identically.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -3872,7 +3872,7 @@ impl PortNum {
 ///
 /// Key native device metrics such as battery level
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct DeviceMetrics {
@@ -3900,7 +3900,7 @@ pub struct DeviceMetrics {
 ///
 /// Weather station or other environmental metrics
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct EnvironmentMetrics {
@@ -3998,7 +3998,7 @@ pub struct EnvironmentMetrics {
 ///
 /// Power Metrics (voltage / current / etc)
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct PowerMetrics {
@@ -4070,7 +4070,7 @@ pub struct PowerMetrics {
 ///
 /// Air quality metrics
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct AirQualityMetrics {
@@ -4178,7 +4178,7 @@ pub struct AirQualityMetrics {
 ///
 /// Local device mesh statistics
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct LocalStats {
@@ -4248,7 +4248,7 @@ pub struct LocalStats {
 ///
 /// Traffic management statistics for mesh network optimization
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct TrafficManagementStats {
@@ -4284,7 +4284,7 @@ pub struct TrafficManagementStats {
 ///
 /// Health telemetry metrics
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct HealthMetrics {
@@ -4304,7 +4304,7 @@ pub struct HealthMetrics {
 ///
 /// Linux host metrics
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct HostMetrics {
@@ -4349,7 +4349,7 @@ pub struct HostMetrics {
 ///
 /// Types of Measurements the telemetry module is equipped to handle
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Telemetry {
@@ -4363,7 +4363,7 @@ pub struct Telemetry {
 /// Nested message and enum types in `Telemetry`.
 pub mod telemetry {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
@@ -4405,7 +4405,7 @@ pub mod telemetry {
 ///
 /// NAU7802 Telemetry configuration, for saving to flash
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct Nau7802Config {
@@ -4421,7 +4421,7 @@ pub struct Nau7802Config {
 ///
 /// SEN5X State, for saving to flash
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Sen5xState {
@@ -4453,7 +4453,7 @@ pub struct Sen5xState {
 ///
 /// Supported I2C Sensors for telemetry in Meshtastic
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -4722,7 +4722,7 @@ impl TelemetrySensorType {
     }
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct XModem {
@@ -4738,7 +4738,7 @@ pub struct XModem {
 /// Nested message and enum types in `XModem`.
 pub mod x_modem {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
@@ -4799,7 +4799,7 @@ pub mod x_modem {
 ///
 /// A GPS Position
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Position {
@@ -4920,7 +4920,7 @@ pub mod position {
     ///
     /// How the location was acquired: manual, onboard GPS, external (EUD) GPS
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
@@ -4977,7 +4977,7 @@ pub mod position {
     /// How the altitude was acquired: manual, GPS int/ext, etc
     /// Default: same as location_source if present
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
@@ -5058,7 +5058,7 @@ pub mod position {
 /// 0xff - broadcast
 /// 0 through 3 - for future use
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct User {
@@ -5115,7 +5115,7 @@ pub struct User {
 ///
 /// A message used in a traceroute
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RouteDiscovery {
@@ -5139,7 +5139,7 @@ pub struct RouteDiscovery {
 ///
 /// A Routing control Data packet handled by the routing module
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Routing {
@@ -5152,7 +5152,7 @@ pub mod routing {
     /// A failure in delivering a message (usually used for routing control messages, but might be provided in addition to ack.fail_id to provide
     /// details on the type of failure).
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
@@ -5280,7 +5280,7 @@ pub mod routing {
         }
     }
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
@@ -5305,7 +5305,7 @@ pub mod routing {
 /// The payload portion fo a packet, this is the actual bytes that are sent
 /// inside a radio packet (because from/to are broken out by the comms library)
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Data {
@@ -5359,7 +5359,7 @@ pub struct Data {
 ///
 /// The actual over-the-mesh message doing KeyVerification
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct KeyVerification {
@@ -5380,7 +5380,7 @@ pub struct KeyVerification {
 ///
 /// The actual over-the-mesh message doing store and forward++
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct StoreForwardPlusPlus {
@@ -5430,7 +5430,7 @@ pub mod store_forward_plus_plus {
     ///
     /// Enum of message types
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
@@ -5497,7 +5497,7 @@ pub mod store_forward_plus_plus {
 ///
 /// Waypoint message, used to share arbitrary locations across the mesh
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Waypoint {
@@ -5538,7 +5538,7 @@ pub struct Waypoint {
 ///
 /// Message for node status
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct StatusMessage {
@@ -5548,7 +5548,7 @@ pub struct StatusMessage {
 ///
 /// This message will be proxied over the PhoneAPI for the client to deliver to the MQTT server
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct MqttClientProxyMessage {
@@ -5572,7 +5572,7 @@ pub mod mqtt_client_proxy_message {
     ///
     /// The actual service envelope payload or text for mqtt pub / sub
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
@@ -5592,7 +5592,7 @@ pub mod mqtt_client_proxy_message {
 /// only payload_variant is sent in the payload portion of the LORA packet.
 /// The other fields are either not sent at all, or sent in the special 16 byte LORA header.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MeshPacket {
@@ -5739,7 +5739,7 @@ pub mod mesh_packet {
     /// field in MeshPacket called 'priority'.
     /// And the transmission queue in the router object is now a priority queue.
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
@@ -5829,7 +5829,7 @@ pub mod mesh_packet {
     ///
     /// Identify if this is a delayed packet
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
@@ -5880,7 +5880,7 @@ pub mod mesh_packet {
     ///
     /// Enum to identify which transport mechanism this packet arrived over
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
@@ -5954,7 +5954,7 @@ pub mod mesh_packet {
         }
     }
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
@@ -5987,7 +5987,7 @@ pub mod mesh_packet {
 /// preshared key, drops all existing nodes, force our node to rejoin this new group)
 /// Full information about a node on the mesh
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NodeInfo {
@@ -6056,7 +6056,7 @@ pub struct NodeInfo {
 /// Note: we don't include position or the user info, because that will come in the
 /// Sent to the phone in response to WantNodes.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct MyNodeInfo {
@@ -6100,7 +6100,7 @@ pub struct MyNodeInfo {
 /// This allows the device code to use fixed maxlen 64 byte strings for messages,
 /// and then extend as needed by emitting multiple records.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct LogRecord {
@@ -6126,7 +6126,7 @@ pub mod log_record {
     ///
     /// Log levels, chosen to match python logging conventions.
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
@@ -6196,7 +6196,7 @@ pub mod log_record {
     }
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct QueueStatus {
@@ -6219,7 +6219,7 @@ pub struct QueueStatus {
 /// It will sit in that descriptor until consumed by the phone,
 /// at which point the next item in the FIFO will be populated.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FromRadio {
@@ -6241,7 +6241,7 @@ pub mod from_radio {
     ///
     /// Log levels, chosen to match python logging conventions.
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
@@ -6326,7 +6326,7 @@ pub mod from_radio {
 /// in the form of push notifications or validation messages when saving
 /// invalid configuration.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ClientNotification {
@@ -6352,7 +6352,7 @@ pub struct ClientNotification {
 /// Nested message and enum types in `ClientNotification`.
 pub mod client_notification {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
@@ -6370,7 +6370,7 @@ pub mod client_notification {
     }
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct KeyVerificationNumberInform {
@@ -6382,7 +6382,7 @@ pub struct KeyVerificationNumberInform {
     pub security_number: u32,
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct KeyVerificationNumberRequest {
@@ -6392,7 +6392,7 @@ pub struct KeyVerificationNumberRequest {
     pub remote_longname: ::prost::alloc::string::String,
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct KeyVerificationFinal {
@@ -6406,19 +6406,19 @@ pub struct KeyVerificationFinal {
     pub verification_characters: ::prost::alloc::string::String,
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct DuplicatedPublicKey {}
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct LowEntropyKey {}
 ///
 /// Individual File info for the device
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct FileInfo {
@@ -6435,7 +6435,7 @@ pub struct FileInfo {
 /// Packets/commands to the radio will be written (reliably) to the toRadio characteristic.
 /// Once the write completes the phone can assume it is handled.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ToRadio {
@@ -6449,7 +6449,7 @@ pub mod to_radio {
     ///
     /// Log levels, chosen to match python logging conventions.
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
@@ -6490,7 +6490,7 @@ pub mod to_radio {
 ///
 /// Compressed message payload
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Compressed {
@@ -6506,7 +6506,7 @@ pub struct Compressed {
 ///
 /// Full info on edges for a single node
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NeighborInfo {
@@ -6530,7 +6530,7 @@ pub struct NeighborInfo {
 ///
 /// A single edge in the mesh
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct Neighbor {
@@ -6556,7 +6556,7 @@ pub struct Neighbor {
 ///
 /// Device metadata response
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct DeviceMetadata {
@@ -6614,7 +6614,7 @@ pub struct DeviceMetadata {
 /// A heartbeat message is sent to the node from the client to keep the connection alive.
 /// This is currently only needed to keep serial connections alive, but can be used by any PhoneAPI.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Heartbeat {
@@ -6626,7 +6626,7 @@ pub struct Heartbeat {
 ///
 /// RemoteHardwarePins associated with a node
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct NodeRemoteHardwarePin {
@@ -6640,7 +6640,7 @@ pub struct NodeRemoteHardwarePin {
     pub pin: ::core::option::Option<RemoteHardwarePin>,
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ChunkedPayload {
@@ -6664,7 +6664,7 @@ pub struct ChunkedPayload {
 ///
 /// Wrapper message for broken repeated oneof support
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ResendChunks {
@@ -6674,7 +6674,7 @@ pub struct ResendChunks {
 ///
 /// Responses to a ChunkedPayload request
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ChunkedPayloadResponse {
@@ -6690,7 +6690,7 @@ pub struct ChunkedPayloadResponse {
 /// Nested message and enum types in `ChunkedPayloadResponse`.
 pub mod chunked_payload_response {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
@@ -6715,7 +6715,7 @@ pub mod chunked_payload_response {
 /// Because they will be used to find firmware filenames in the android app for OTA updates.
 /// To match the old style filenames, _ is converted to -, p is converted to .
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -7395,7 +7395,7 @@ impl HardwareModel {
 ///
 /// Shared constants between device and phone
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -7437,7 +7437,7 @@ impl Constants {
 /// If you encounter a fault code, please post on the meshtastic.discourse.group
 /// and we'll try to help.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -7539,7 +7539,7 @@ impl CriticalErrorCode {
 /// Enum to indicate to clients whether this firmware is a special firmware build, like an event.
 /// The first 16 values are reserved for non-event special firmwares, like the Smart Citizen use case.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -7602,7 +7602,7 @@ impl FirmwareEdition {
 /// Each value represents a ModuleConfigType that can be toggled as excluded
 /// by setting its corresponding bit in the `excluded_modules` bitmask field.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -7710,7 +7710,7 @@ impl ExcludedModules {
 /// This message is used to do settings operations to both remote AND local nodes.
 /// (Prior to 1.2 these operations were done via special ToRadio operations)
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AdminMessage {
@@ -7733,7 +7733,7 @@ pub mod admin_message {
     ///
     /// Input event message to be sent to the node.
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct InputEvent {
@@ -7758,7 +7758,7 @@ pub mod admin_message {
     /// User is requesting an over the air update.
     /// Node will reboot into the OTA loader
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct OtaEvent {
@@ -7775,7 +7775,7 @@ pub mod admin_message {
     ///
     /// TODO: REPLACE
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
@@ -7861,7 +7861,7 @@ pub mod admin_message {
     ///
     /// TODO: REPLACE
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
@@ -7970,7 +7970,7 @@ pub mod admin_message {
         }
     }
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
@@ -8016,7 +8016,7 @@ pub mod admin_message {
     ///
     /// TODO: REPLACE
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
@@ -8268,7 +8268,7 @@ pub mod admin_message {
 ///
 /// Parameters for setting up Meshtastic for ameteur radio usage
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HamParameters {
@@ -8294,7 +8294,7 @@ pub struct HamParameters {
 ///
 /// Response envelope for node_remote_hardware_pins
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NodeRemoteHardwarePinsResponse {
@@ -8304,7 +8304,7 @@ pub struct NodeRemoteHardwarePinsResponse {
     pub node_remote_hardware_pins: ::prost::alloc::vec::Vec<NodeRemoteHardwarePin>,
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SharedContact {
@@ -8328,7 +8328,7 @@ pub struct SharedContact {
 ///
 /// This message is used by a client to initiate or complete a key verification
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct KeyVerificationAdmin {
@@ -8352,7 +8352,7 @@ pub mod key_verification_admin {
     ///
     /// Three stages of this request.
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
@@ -8408,7 +8408,7 @@ pub mod key_verification_admin {
     }
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct SensorConfig {
@@ -8422,7 +8422,7 @@ pub struct SensorConfig {
     pub sen5x_config: ::core::option::Option<Sen5xConfig>,
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct Scd4xConfig {
@@ -8456,7 +8456,7 @@ pub struct Scd4xConfig {
     pub set_power_mode: ::core::option::Option<bool>,
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct Sen5xConfig {
@@ -8472,7 +8472,7 @@ pub struct Sen5xConfig {
 ///
 /// Firmware update mode for OTA updates
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -8517,7 +8517,7 @@ impl OtaMode {
 /// No DISABLED channels are included.
 /// This abstraction is used only on the the 'app side' of the world (ie python, javascript and android etc) to show a group of Channels as a (long) URL
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChannelSet {
@@ -8533,7 +8533,7 @@ pub struct ChannelSet {
 ///
 /// Packets for the official ATAK Plugin
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct TakPacket {
@@ -8563,7 +8563,7 @@ pub mod tak_packet {
     ///
     /// The payload of the packet
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
@@ -8586,7 +8586,7 @@ pub mod tak_packet {
 ///
 /// ATAK GeoChat message
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GeoChat {
@@ -8607,7 +8607,7 @@ pub struct GeoChat {
 /// ATAK Group
 /// <__group role='Team Member' name='Cyan'/>
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Group {
@@ -8625,7 +8625,7 @@ pub struct Group {
 /// ATAK EUD Status
 /// <status battery='100' />
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Status {
@@ -8638,7 +8638,7 @@ pub struct Status {
 /// ATAK Contact
 /// <contact endpoint='0.0.0.0:4242:tcp' phone='+12345678' callsign='FALKE'/>
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Contact {
@@ -8657,7 +8657,7 @@ pub struct Contact {
 ///
 /// Position Location Information from ATAK
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Pli {
@@ -8685,7 +8685,7 @@ pub struct Pli {
     pub course: u32,
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -8786,7 +8786,7 @@ impl Team {
 ///
 /// Role of the group member
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -8857,7 +8857,7 @@ impl MemberRole {
 ///
 /// Canned message module configuration.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct CannedMessageModuleConfig {
@@ -8867,7 +8867,7 @@ pub struct CannedMessageModuleConfig {
     pub messages: ::prost::alloc::string::String,
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LocalConfig {
@@ -8911,7 +8911,7 @@ pub struct LocalConfig {
     pub security: ::core::option::Option<config::SecurityConfig>,
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LocalModuleConfig {
@@ -8990,7 +8990,7 @@ pub struct LocalModuleConfig {
 /// This abstraction is used to contain any configuration for provisioning a node on any client.
 /// It is useful for importing and exporting configurations.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeviceProfile {
@@ -9030,7 +9030,7 @@ pub struct DeviceProfile {
 ///
 /// Position with static location information only for NodeDBLite
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct PositionLite {
@@ -9061,7 +9061,7 @@ pub struct PositionLite {
     pub location_source: i32,
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct UserLite {
@@ -9107,7 +9107,7 @@ pub struct UserLite {
     pub is_unmessagable: ::core::option::Option<bool>,
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NodeInfoLite {
@@ -9177,7 +9177,7 @@ pub struct NodeInfoLite {
 /// flash) it would be better to use some sort of append only data structure for
 /// the receive queue and use the preferences store for the other stuff
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeviceState {
@@ -9230,7 +9230,7 @@ pub struct DeviceState {
     pub node_remote_hardware_pins: ::prost::alloc::vec::Vec<NodeRemoteHardwarePin>,
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NodeDatabase {
@@ -9248,7 +9248,7 @@ pub struct NodeDatabase {
 ///
 /// The on-disk saved channels
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChannelFile {
@@ -9266,7 +9266,7 @@ pub struct ChannelFile {
 ///
 /// The on-disk backup of the node's preferences
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BackupPreferences {
@@ -9296,7 +9296,7 @@ pub struct BackupPreferences {
     pub owner: ::core::option::Option<User>,
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct SensorData {
@@ -9311,7 +9311,7 @@ pub struct SensorData {
 pub mod sensor_data {
     /// The sensor data, either as a float or an uint32
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(Clone, Copy, PartialEq, ::prost::Oneof)]
@@ -9323,7 +9323,7 @@ pub mod sensor_data {
     }
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InterdeviceMessage {
@@ -9335,7 +9335,7 @@ pub struct InterdeviceMessage {
 pub mod interdevice_message {
     /// The message data
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
@@ -9347,7 +9347,7 @@ pub mod interdevice_message {
     }
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -9412,7 +9412,7 @@ impl MessageType {
 ///
 /// This message wraps a MeshPacket with extra metadata about the sender and how it arrived.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ServiceEnvelope {
@@ -9434,7 +9434,7 @@ pub struct ServiceEnvelope {
 ///
 /// Information about a node intended to be reported unencrypted to a map using MQTT.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct MapReport {
@@ -9501,7 +9501,7 @@ pub struct MapReport {
 ///
 /// TODO: REPLACE
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Paxcount {
@@ -9521,7 +9521,7 @@ pub struct Paxcount {
 /// Note: There are no 'PowerMon' messages normally in use (PowerMons are sent only as structured logs - slogs).
 /// But we wrap our State enum in this message to effectively nest a namespace (without our linter yelling at us)
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct PowerMon {}
@@ -9530,7 +9530,7 @@ pub mod power_mon {
     /// Any significant power changing event in meshtastic should be tagged with a powermon state transition.
     /// If you are making new meshtastic features feel free to add new entries at the end of this definition.
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
@@ -9618,7 +9618,7 @@ pub mod power_mon {
 ///
 /// PowerStress testing support via the C++ PowerStress module
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct PowerStressMessage {
@@ -9636,7 +9636,7 @@ pub mod power_stress_message {
     /// note: senders should probably set want_response in their request packets, so that they can know when the state
     /// machine has started processing their request
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
@@ -9762,7 +9762,7 @@ pub mod power_stress_message {
 /// It should be off by default and then protected based on some TBD mechanism
 /// (a special channel once multichannel support is included?)
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct HardwareMessage {
@@ -9785,7 +9785,7 @@ pub mod hardware_message {
     ///
     /// TODO: REPLACE
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
@@ -9854,7 +9854,7 @@ pub mod hardware_message {
 ///
 /// Canned message module configuration.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RtttlConfig {
@@ -9866,7 +9866,7 @@ pub struct RtttlConfig {
 ///
 /// TODO: REPLACE
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct StoreAndForward {
@@ -9884,7 +9884,7 @@ pub mod store_and_forward {
     ///
     /// TODO: REPLACE
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct Statistics {
@@ -9928,7 +9928,7 @@ pub mod store_and_forward {
     ///
     /// TODO: REPLACE
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct History {
@@ -9949,7 +9949,7 @@ pub mod store_and_forward {
     ///
     /// TODO: REPLACE
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct Heartbeat {
@@ -9966,7 +9966,7 @@ pub mod store_and_forward {
     /// 001 - 063 = From Router
     /// 064 - 127 = From Client
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(
@@ -10084,7 +10084,7 @@ pub mod store_and_forward {
     ///
     /// TODO: REPLACE
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
     #[cfg_attr(feature = "ts-gen", derive(specta::Type))]
     #[cfg_attr(feature = "strum", derive(strum::EnumCount, strum::EnumIter))]
     #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]


### PR DESCRIPTION
**Summary**
- `echo_response: true` for all stream_api methods
- `serde(rename_all = "snake_case")`

**Related Issues**
No related issues.

**Proposed Changes**
- Enabled `echo_response` for all stream_api methods. I don't know why it was disabled, it makes PacketRouter useless for methods like `update_config`, `update_user`, etc
- Changed `serde(rename_all = "camelCase")` attribute to `serde(rename_all = "snake_case")` in `build.rs`. Same situation, I don't know why camelCase was used here. Protobuf protos are using snake_case field names, so I think we should use the same. This change will allow us to use static field names for referencing, for example using [`nameof`](https://crates.io/crates/nameof) crate.

**Checklist**
- [x] Tests pass locally (I've tested config saving)
- [x] Nothing to change in documentation
