### PR TITLE
Abort JoinHandle when futures are cancelled/dropped

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ futures-util = "0.3.31"
 rand = "0.9.0"
 tokio = { version = "1.43.0", features = ["full"], optional = true }
 tokio-serial = { version = "5.4.5", optional = true }
-tokio-util = { version = "0.7.13", optional = true }
+tokio-util = { version = "0.7.13", optional = true, features = ["rt"] }
 prost = "0.14"
 log = "0.4.25"
 

--- a/src/connections/handlers.rs
+++ b/src/connections/handlers.rs
@@ -36,8 +36,13 @@ where
                 Ok(())
             }
             e = handle => {
-                debug!("Read handler unexpectedly terminated: {e:#?}");
-                e
+                if cancellation_token.is_cancelled() {
+                    debug!("Read handler finished during cancellation");
+                    Ok(())
+                } else {
+                    error!("Read handler unexpectedly terminated: {e:#?}");
+                    e
+                }
             }
         }
     })
@@ -106,7 +111,12 @@ where
                 Ok(())
             }
             write_result = handle => {
-                write_result.inspect_err(|e| error!("Write handler unexpectedly terminated {e:?}"))
+                if cancellation_token.is_cancelled() {
+                    debug!("Write handler finished during cancellation");
+                    Ok(())
+                } else {
+                    write_result.inspect_err(|e| error!("Write handler unexpectedly terminated {e:?}"))
+                }
             }
         }
     })
@@ -151,8 +161,13 @@ pub fn spawn_processing_handler(
                 Ok(())
             }
             _ = handle => {
-                error!("Message processing handler unexpectedly terminated");
-                Err(Error::InternalChannelError(InternalChannelError::ChannelClosedEarly {}))
+                if cancellation_token.is_cancelled() {
+                    debug!("Message processing handler finished during cancellation");
+                    Ok(())
+                } else {
+                    error!("Message processing handler unexpectedly terminated");
+                    Err(Error::InternalChannelError(InternalChannelError::ChannelClosedEarly {}))
+                }
             }
         }
     })
@@ -186,9 +201,14 @@ pub fn spawn_heartbeat_handler(
                 Ok(())
             }
             write_result = handle => {
-                write_result.inspect_err(|e|
-                    error!("Heartbeat handler unexpectedly terminated {e:?}")
-                )
+                if cancellation_token.is_cancelled() {
+                    debug!("Heartbeat handler finished during cancellation");
+                    Ok(())
+                } else {
+                    write_result.inspect_err(|e|
+                        error!("Heartbeat handler unexpectedly terminated {e:?}")
+                    )
+                }
             }
         }
     })

--- a/src/connections/stream_api.rs
+++ b/src/connections/stream_api.rs
@@ -5,7 +5,7 @@ use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     sync::mpsc::UnboundedSender,
 };
-use tokio_util::sync::CancellationToken;
+use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
 
 use crate::{errors_internal::Error, protobufs, types::EncodedToRadioPacketWithHeader, utils};
 use crate::{
@@ -18,7 +18,7 @@ use super::{
     wrappers::{
         encoded_data::{EncodedMeshPacketData, EncodedToRadioPacket, IncomingStreamData},
         mesh_channel::MeshChannel,
-        AbortingJoinHandle, NodeId,
+        NodeId,
     },
     PacketDestination, PacketRouter,
 };
@@ -69,13 +69,13 @@ pub struct StreamApi;
 pub struct ConnectedStreamApi<State = state::Configured> {
     write_input_tx: UnboundedSender<EncodedToRadioPacketWithHeader>,
 
-    read_handle: AbortingJoinHandle,
-    write_handle: AbortingJoinHandle,
-    processing_handle: AbortingJoinHandle,
-    heartbeat_handle: AbortingJoinHandle,
+    read_handle: AbortOnDropHandle<Result<(), Error>>,
+    write_handle: AbortOnDropHandle<Result<(), Error>>,
+    processing_handle: AbortOnDropHandle<Result<(), Error>>,
+    heartbeat_handle: AbortOnDropHandle<Result<(), Error>>,
     /// An optional handle to a background task that bridges data between a high-level
     /// stream and a low-level transport (e.g. BLE).
-    bridge_handle: Option<AbortingJoinHandle>,
+    bridge_handle: Option<AbortOnDropHandle<Result<(), Error>>>,
 
     cancellation_token: CancellationToken,
 
@@ -88,7 +88,7 @@ pub struct StreamHandle<T: AsyncReadExt + AsyncWriteExt + Send> {
     /// The underlying stream.
     pub stream: T,
     /// An optional join handle that processes data on the other side of the stream.
-    pub join_handle: Option<AbortingJoinHandle>,
+    pub join_handle: Option<AbortOnDropHandle<Result<(), Error>>>,
 }
 
 impl<T: AsyncReadExt + AsyncWriteExt + Send> StreamHandle<T> {
@@ -445,24 +445,28 @@ impl StreamApi {
         let (read_stream, write_stream) = tokio::io::split(stream_handle.stream);
         let cancellation_token = CancellationToken::new();
 
-        let read_handle =
-            handlers::spawn_read_handler(cancellation_token.clone(), read_stream, read_output_tx)
-                .into();
+        let read_handle = AbortOnDropHandle::new(handlers::spawn_read_handler(
+            cancellation_token.clone(),
+            read_stream,
+            read_output_tx,
+        ));
 
-        let write_handle =
-            handlers::spawn_write_handler(cancellation_token.clone(), write_stream, write_input_rx)
-                .into();
+        let write_handle = AbortOnDropHandle::new(handlers::spawn_write_handler(
+            cancellation_token.clone(),
+            write_stream,
+            write_input_rx,
+        ));
 
-        let processing_handle = handlers::spawn_processing_handler(
+        let processing_handle = AbortOnDropHandle::new(handlers::spawn_processing_handler(
             cancellation_token.clone(),
             read_output_rx,
             decoded_packet_tx,
-        )
-        .into();
+        ));
 
-        let heartbeat_handle =
-            handlers::spawn_heartbeat_handler(cancellation_token.clone(), write_input_tx.clone())
-                .into();
+        let heartbeat_handle = AbortOnDropHandle::new(handlers::spawn_heartbeat_handler(
+            cancellation_token.clone(),
+            write_input_tx.clone(),
+        ));
 
         // Return channel for receiving decoded packets
 

--- a/src/connections/stream_api.rs
+++ b/src/connections/stream_api.rs
@@ -1,11 +1,9 @@
-use futures_util::future::join3;
 use log::trace;
 use prost::Message;
 use std::{fmt::Display, marker::PhantomData};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     sync::mpsc::UnboundedSender,
-    task::JoinHandle,
 };
 use tokio_util::sync::CancellationToken;
 
@@ -20,7 +18,7 @@ use super::{
     wrappers::{
         encoded_data::{EncodedMeshPacketData, EncodedToRadioPacket, IncomingStreamData},
         mesh_channel::MeshChannel,
-        NodeId,
+        AbortingJoinHandle, NodeId,
     },
     PacketDestination, PacketRouter,
 };
@@ -71,10 +69,13 @@ pub struct StreamApi;
 pub struct ConnectedStreamApi<State = state::Configured> {
     write_input_tx: UnboundedSender<EncodedToRadioPacketWithHeader>,
 
-    read_handle: JoinHandle<Result<(), Error>>,
-    write_handle: JoinHandle<Result<(), Error>>,
-    processing_handle: JoinHandle<Result<(), Error>>,
-    heartbeat_handle: JoinHandle<Result<(), Error>>,
+    read_handle: AbortingJoinHandle,
+    write_handle: AbortingJoinHandle,
+    processing_handle: AbortingJoinHandle,
+    heartbeat_handle: AbortingJoinHandle,
+    /// An optional handle to a background task that bridges data between a high-level
+    /// stream and a low-level transport (e.g. BLE).
+    bridge_handle: Option<AbortingJoinHandle>,
 
     cancellation_token: CancellationToken,
 
@@ -87,7 +88,7 @@ pub struct StreamHandle<T: AsyncReadExt + AsyncWriteExt + Send> {
     /// The underlying stream.
     pub stream: T,
     /// An optional join handle that processes data on the other side of the stream.
-    pub join_handle: Option<JoinHandle<Result<(), Error>>>,
+    pub join_handle: Option<AbortingJoinHandle>,
 }
 
 impl<T: AsyncReadExt + AsyncWriteExt + Send> StreamHandle<T> {
@@ -422,7 +423,7 @@ impl StreamApi {
     ///
     pub async fn connect<S>(
         self,
-        stream_handle: StreamHandle<S>,
+        mut stream_handle: StreamHandle<S>,
     ) -> (PacketReceiver, ConnectedStreamApi<state::Connected>)
     where
         S: AsyncReadExt + AsyncWriteExt + Send + 'static,
@@ -440,28 +441,28 @@ impl StreamApi {
 
         // Spawn worker threads with kill switch
 
+        let bridge_handle = stream_handle.join_handle.take();
         let (read_stream, write_stream) = tokio::io::split(stream_handle.stream);
         let cancellation_token = CancellationToken::new();
 
         let read_handle =
-            handlers::spawn_read_handler(cancellation_token.clone(), read_stream, read_output_tx);
+            handlers::spawn_read_handler(cancellation_token.clone(), read_stream, read_output_tx)
+                .into();
 
         let write_handle =
-            handlers::spawn_write_handler(cancellation_token.clone(), write_stream, write_input_rx);
+            handlers::spawn_write_handler(cancellation_token.clone(), write_stream, write_input_rx)
+                .into();
 
         let processing_handle = handlers::spawn_processing_handler(
             cancellation_token.clone(),
             read_output_rx,
             decoded_packet_tx,
-        );
+        )
+        .into();
 
         let heartbeat_handle =
-            handlers::spawn_heartbeat_handler(cancellation_token.clone(), write_input_tx.clone());
-
-        // Persist channels and kill switch to struct
-
-        let write_input_tx = write_input_tx;
-        let cancellation_token = cancellation_token;
+            handlers::spawn_heartbeat_handler(cancellation_token.clone(), write_input_tx.clone())
+                .into();
 
         // Return channel for receiving decoded packets
 
@@ -473,6 +474,7 @@ impl StreamApi {
                 write_handle,
                 processing_handle,
                 heartbeat_handle,
+                bridge_handle,
                 cancellation_token,
                 typestate: PhantomData,
             },
@@ -549,13 +551,14 @@ impl ConnectedStreamApi<state::Connected> {
             write_handle: self.write_handle,
             processing_handle: self.processing_handle,
             heartbeat_handle: self.heartbeat_handle,
+            bridge_handle: self.bridge_handle,
             cancellation_token: self.cancellation_token,
             typestate: PhantomData,
         })
     }
 }
 
-impl ConnectedStreamApi<state::Configured> {
+impl<State> ConnectedStreamApi<State> {
     /// A method to disconnect from a radio. This method will close all channels and
     /// join all worker threads. If connected via serial or TCP, this will also trigger
     /// the radio to terminate its current connection.
@@ -600,13 +603,23 @@ impl ConnectedStreamApi<state::Configured> {
 
         // Close worker threads
 
-        let (read_result, write_result, processing_result) =
-            join3(self.read_handle, self.write_handle, self.processing_handle).await;
+        let (read_result, write_result, processing_result, heartbeat_result) = tokio::join!(
+            self.read_handle,
+            self.write_handle,
+            self.processing_handle,
+            self.heartbeat_handle
+        );
+
+        if let Some(handle) = self.bridge_handle {
+            handle.abort();
+            let _ = handle.await;
+        }
 
         // Note: we only return the first error.
         read_result??;
         write_result??;
         processing_result??;
+        heartbeat_result??;
 
         trace!("Handlers fully disconnected");
 

--- a/src/connections/wrappers.rs
+++ b/src/connections/wrappers.rs
@@ -1,3 +1,9 @@
+use std::ops::Deref;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use tokio::task::{JoinError, JoinHandle};
+
 use crate::errors_internal::Error;
 
 /// A helper struct representing the ID of a node in the mesh.
@@ -238,5 +244,76 @@ pub mod mesh_channel {
         fn from(channel: u32) -> Self {
             MeshChannel(channel)
         }
+    }
+}
+
+/// A wrapper around a [`JoinHandle`] that will automatically abort the underlying task
+/// when it is dropped.
+#[derive(Debug)]
+pub struct AbortingJoinHandle(JoinHandle<Result<(), Error>>);
+
+impl From<JoinHandle<Result<(), Error>>> for AbortingJoinHandle {
+    fn from(handle: JoinHandle<Result<(), Error>>) -> Self {
+        Self(handle)
+    }
+}
+
+impl Deref for AbortingJoinHandle {
+    type Target = JoinHandle<Result<(), Error>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Drop for AbortingJoinHandle {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+impl std::future::Future for AbortingJoinHandle {
+    type Output = Result<Result<(), Error>, JoinError>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.0).poll(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_aborting_join_handle() {
+        let (mut tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let handle = tokio::spawn(async move {
+            let _rx = rx;
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+            Ok(())
+        });
+
+        let aborting_handle: AbortingJoinHandle = handle.into();
+        drop(aborting_handle);
+
+        // If the task was aborted, the receiver `rx` will be dropped, causing `tx.is_closed()` to
+        // become true.
+        tokio::time::timeout(std::time::Duration::from_secs(5), tx.closed())
+            .await
+            .expect("Task was not aborted within timeout");
+    }
+
+    #[tokio::test]
+    async fn test_aborting_join_handle_completion() {
+        let handle = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            Ok(())
+        });
+
+        let aborting_handle: AbortingJoinHandle = handle.into();
+
+        let result = aborting_handle.await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_ok());
     }
 }

--- a/src/connections/wrappers.rs
+++ b/src/connections/wrappers.rs
@@ -1,9 +1,3 @@
-use std::ops::Deref;
-use std::pin::Pin;
-use std::task::{Context, Poll};
-
-use tokio::task::{JoinError, JoinHandle};
-
 use crate::errors_internal::Error;
 
 /// A helper struct representing the ID of a node in the mesh.
@@ -247,73 +241,5 @@ pub mod mesh_channel {
     }
 }
 
-/// A wrapper around a [`JoinHandle`] that will automatically abort the underlying task
-/// when it is dropped.
-#[derive(Debug)]
-pub struct AbortingJoinHandle(JoinHandle<Result<(), Error>>);
-
-impl From<JoinHandle<Result<(), Error>>> for AbortingJoinHandle {
-    fn from(handle: JoinHandle<Result<(), Error>>) -> Self {
-        Self(handle)
-    }
-}
-
-impl Deref for AbortingJoinHandle {
-    type Target = JoinHandle<Result<(), Error>>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl Drop for AbortingJoinHandle {
-    fn drop(&mut self) {
-        self.0.abort();
-    }
-}
-
-impl std::future::Future for AbortingJoinHandle {
-    type Output = Result<Result<(), Error>, JoinError>;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        Pin::new(&mut self.0).poll(cx)
-    }
-}
-
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn test_aborting_join_handle() {
-        let (mut tx, rx) = tokio::sync::oneshot::channel::<()>();
-        let handle = tokio::spawn(async move {
-            let _rx = rx;
-            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
-            Ok(())
-        });
-
-        let aborting_handle: AbortingJoinHandle = handle.into();
-        drop(aborting_handle);
-
-        // If the task was aborted, the receiver `rx` will be dropped, causing `tx.is_closed()` to
-        // become true.
-        tokio::time::timeout(std::time::Duration::from_secs(5), tx.closed())
-            .await
-            .expect("Task was not aborted within timeout");
-    }
-
-    #[tokio::test]
-    async fn test_aborting_join_handle_completion() {
-        let handle = tokio::spawn(async move {
-            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-            Ok(())
-        });
-
-        let aborting_handle: AbortingJoinHandle = handle.into();
-
-        let result = aborting_handle.await;
-        assert!(result.is_ok());
-        assert!(result.unwrap().is_ok());
-    }
-}
+mod tests {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,6 @@ pub mod api {
     pub use crate::connections::stream_api::ConnectedStreamApi;
     pub use crate::connections::stream_api::StreamApi;
     pub use crate::connections::stream_api::StreamHandle;
-    pub use crate::connections::wrappers::AbortingJoinHandle;
 }
 
 /// This module contains the global `Error` type of the library. This enum implements

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ pub mod api {
     pub use crate::connections::stream_api::ConnectedStreamApi;
     pub use crate::connections::stream_api::StreamApi;
     pub use crate::connections::stream_api::StreamHandle;
+    pub use crate::connections::wrappers::AbortingJoinHandle;
 }
 
 /// This module contains the global `Error` type of the library. This enum implements

--- a/src/utils_internal.rs
+++ b/src/utils_internal.rs
@@ -351,7 +351,7 @@ where
 
     Ok(StreamHandle {
         stream: client,
-        join_handle: Some(handle),
+        join_handle: Some(handle.into()),
     })
 }
 

--- a/src/utils_internal.rs
+++ b/src/utils_internal.rs
@@ -351,7 +351,7 @@ where
 
     Ok(StreamHandle {
         stream: client,
-        join_handle: Some(handle.into()),
+        join_handle: Some(tokio_util::task::AbortOnDropHandle::new(handle)),
     })
 }
 


### PR DESCRIPTION
**Summary**
This PR implements automatic task abortion for background tasks to ensure they are cleaned up when their handles are dropped. It refactors the management of read, write, processing, heartbeat, and bridge handlers to use `tokio_util::task::AbortOnDropHandle`.

This prevents resource leaks and ensures clean shutdowns when operations (such as `connect()`) are cancelled, for example by a `tokio::time::timeout`.

**Related Issues**
Fixes #88

**Proposed Changes**
- **Robust Task Management:** Refactor `ConnectedStreamApi` and `StreamHandle` to use `AbortOnDropHandle`. This ensures that background tasks are aborted immediately when the API object is dropped or when a `connect()` future is cancelled.
- **Bridge Support:** Properly manages the `bridge_handle` for low-level transports (like BLE), ensuring it is aborted and awaited during disconnection.
- **Dependency Update:** Enabled the `rt` feature for `tokio-util` in `Cargo.toml`.

**Checklist**
- [x] Tests pass locally
- [x] Documentation updated if needed
