### PR TITLE
Handle very rare stream failure when packets contain magic bytes

### DIFF
--- a/src/connections/stream_buffer.rs
+++ b/src/connections/stream_buffer.rs
@@ -37,7 +37,9 @@ pub enum StreamBufferError {
     MissingLSB { lsb_index: usize },
     #[error("Detected malformed packet, packet buffer contains a framing byte at index {next_packet_start_idx}")]
     MalformedPacket { next_packet_start_idx: usize },
-    #[error("Declared packet size of {declared_size} bytes exceeds max packet size of {max_size} bytes")]
+    #[error(
+        "Declared packet size of {declared_size} bytes exceeds max packet size of {max_size} bytes"
+    )]
     ImplausiblePacketSize {
         declared_size: usize,
         max_size: usize,
@@ -139,7 +141,8 @@ impl StreamBuffer {
                             "Header declares implausible packet size {declared_size} (max {max_size}), discarding false header"
                         );
 
-                        self.buffer.drain(0..PACKET_HEADER_SIZE.min(self.buffer.len()));
+                        self.buffer
+                            .drain(0..PACKET_HEADER_SIZE.min(self.buffer.len()));
                         continue; // Don't need more data to continue, purge false header
                     }
                     StreamBufferError::DecodeFailure { .. } => {

--- a/src/connections/stream_buffer.rs
+++ b/src/connections/stream_buffer.rs
@@ -37,11 +37,19 @@ pub enum StreamBufferError {
     MissingLSB { lsb_index: usize },
     #[error("Detected malformed packet, packet buffer contains a framing byte at index {next_packet_start_idx}")]
     MalformedPacket { next_packet_start_idx: usize },
+    #[error("Declared packet size of {declared_size} bytes exceeds max packet size of {max_size} bytes")]
+    ImplausiblePacketSize {
+        declared_size: usize,
+        max_size: usize,
+    },
     #[error(transparent)]
     DecodeFailure(#[from] prost::DecodeError),
 }
 
 const PACKET_HEADER_SIZE: usize = 4;
+
+// Matches firmware's MAX_TO_FROM_RADIO_SIZE (src/mesh/PhoneAPI.h).
+const MAX_TO_FROM_RADIO_SIZE: usize = 512;
 
 impl StreamBuffer {
     /// Creates a new StreamBuffer instance that will send decoded FromRadio packets
@@ -122,6 +130,17 @@ impl StreamBuffer {
                           );
 
                         continue; // Don't need more data to continue, purge from buffer
+                    }
+                    StreamBufferError::ImplausiblePacketSize {
+                        declared_size,
+                        max_size,
+                    } => {
+                        error!(
+                            "Header declares implausible packet size {declared_size} (max {max_size}), discarding false header"
+                        );
+
+                        self.buffer.drain(0..PACKET_HEADER_SIZE.min(self.buffer.len()));
+                        continue; // Don't need more data to continue, purge false header
                     }
                     StreamBufferError::DecodeFailure { .. } => {
                         error!("Failed to decode chunk from packet, this does not affect the next iteration");
@@ -285,6 +304,13 @@ impl StreamBuffer {
         // Combine MSB and LSB of incoming packet size bytes
         // Recall that packet size doesn't include the first four magic bytes
         let incoming_packet_data_size: usize = usize::from(u16::from_le_bytes([*lsb, *msb]));
+
+        if incoming_packet_data_size > MAX_TO_FROM_RADIO_SIZE {
+            return Err(StreamBufferError::ImplausiblePacketSize {
+                declared_size: incoming_packet_data_size,
+                max_size: MAX_TO_FROM_RADIO_SIZE,
+            });
+        }
 
         Ok(incoming_packet_data_size)
     }
@@ -717,6 +743,46 @@ mod tests {
     /// within the payload and to discard the malformed packet.
     #[tokio::test]
     async fn detect_malformed_packets_with_internal_header_sequence() {}
+
+    /// Test for a [0x94, 0xc3] sequence occurring by chance inside another packet's
+    /// payload. Expected behavior is that the bogus size is rejected and the buffer
+    /// resyncs on the next real packet.
+    #[tokio::test]
+    async fn resync_after_false_header_match_with_implausible_size() {
+        // Arrange
+
+        let payload_variant_1 =
+            protobufs::from_radio::PayloadVariant::MyInfo(protobufs::MyNodeInfo::default());
+        let payload_variant_2 =
+            protobufs::from_radio::PayloadVariant::MyInfo(protobufs::MyNodeInfo::default());
+
+        let (packet_1, packet_data_1) = mock_encoded_from_radio_packet(payload_variant_1, None);
+        let (packet_2, packet_data_2) = mock_encoded_from_radio_packet(payload_variant_2, None);
+
+        let encoded_packet_1 = format_data_packet(packet_data_1.into()).unwrap();
+        let encoded_packet_2 = format_data_packet(packet_data_2.into()).unwrap();
+
+        // Header with a declared size (big-endian MSB/LSB) larger than MAX_TO_FROM_RADIO_SIZE.
+        let false_header = vec![0x94, 0xc3, 254, 6];
+
+        let (mock_tx, mut mock_rx) = unbounded_channel::<protobufs::FromRadio>();
+
+        // Act
+
+        let mut buffer = StreamBuffer::new(mock_tx);
+
+        let mut data = Vec::new();
+        data.extend_from_slice(encoded_packet_1.data());
+        data.extend_from_slice(&false_header);
+        data.extend_from_slice(encoded_packet_2.data());
+        buffer.process_incoming_bytes(data.into());
+
+        // Assert
+
+        assert_eq!(timeout_test(mock_rx.recv(), None).await, Some(packet_1));
+        assert_eq!(timeout_test(mock_rx.recv(), None).await, Some(packet_2));
+        assert_eq!(buffer.buffer.len(), 0);
+    }
 
     #[tokio::test]
     async fn process_log_lines() {

--- a/src/connections/stream_buffer.rs
+++ b/src/connections/stream_buffer.rs
@@ -764,6 +764,7 @@ mod tests {
         assert!(
             encoded_outer
                 .data_vec()
+                [PACKET_HEADER_SIZE..]
                 .windows(2)
                 .any(|w| w == [0x94, 0xc3]),
             "outer_packet no longer reproduces the coincidental header collision"

--- a/src/connections/stream_buffer.rs
+++ b/src/connections/stream_buffer.rs
@@ -762,9 +762,7 @@ mod tests {
         };
         let encoded_outer = format_data_packet(outer_packet.encode_to_vec().into()).unwrap();
         assert!(
-            encoded_outer
-                .data_vec()
-                [PACKET_HEADER_SIZE..]
+            encoded_outer.data_vec()[PACKET_HEADER_SIZE..]
                 .windows(2)
                 .any(|w| w == [0x94, 0xc3]),
             "outer_packet no longer reproduces the coincidental header collision"

--- a/src/connections/stream_buffer.rs
+++ b/src/connections/stream_buffer.rs
@@ -762,7 +762,10 @@ mod tests {
         };
         let encoded_outer = format_data_packet(outer_packet.encode_to_vec().into()).unwrap();
         assert!(
-            encoded_outer.data_vec().windows(2).any(|w| w == [0x94, 0xc3]),
+            encoded_outer
+                .data_vec()
+                .windows(2)
+                .any(|w| w == [0x94, 0xc3]),
             "outer_packet no longer reproduces the coincidental header collision"
         );
 

--- a/src/connections/stream_buffer.rs
+++ b/src/connections/stream_buffer.rs
@@ -352,6 +352,13 @@ impl StreamBuffer {
             .map(|idx| idx + packet_data_start_index);
 
         if let Some(next_packet_start_idx) = next_packet_start_index {
+            // Only malformed if it doesn't decode at the declared length.
+            let declared_packet =
+                &self.buffer[packet_data_start_index..packet_data_start_index + packet_data_size];
+            if protobufs::FromRadio::decode(declared_packet).is_ok() {
+                return Ok(());
+            }
+
             // Remove malformed packet from buffer
             self.buffer.drain(..next_packet_start_idx);
 
@@ -785,6 +792,83 @@ mod tests {
         assert_eq!(timeout_test(mock_rx.recv(), None).await, Some(packet_1));
         assert_eq!(timeout_test(mock_rx.recv(), None).await, Some(packet_2));
         assert_eq!(buffer.buffer.len(), 0);
+    }
+
+    /// `outer_packet`'s serialized bytes coincidentally contain [0x94, 0xc3],
+    /// the same collision that caused a real hang before MAX_TO_FROM_RADIO_SIZE
+    /// was added. Identity fields are placeholders; device_metrics is unchanged
+    /// since that's what produces the collision. Expected behavior is that both
+    /// packets decode, since the coincidental match doesn't mean outer_packet
+    /// is malformed.
+    #[tokio::test]
+    async fn resync_after_coincidental_header_match_inside_packet_payload() {
+        let outer_packet = protobufs::FromRadio {
+            id: 0,
+            payload_variant: Some(protobufs::from_radio::PayloadVariant::NodeInfo(
+                protobufs::NodeInfo {
+                    num: 1234567890,
+                    user: Some(protobufs::User {
+                        id: "!deadbeef".to_string(),
+                        long_name: "Test Node".to_string(),
+                        short_name: "TEST".to_string(),
+                        hw_model: protobufs::HardwareModel::HeltecV3 as i32,
+                        public_key: vec![0xab; 32],
+                        ..Default::default()
+                    }),
+                    device_metrics: Some(protobufs::DeviceMetrics {
+                        battery_level: Some(100),
+                        voltage: Some(4.219),
+                        channel_utilization: Some(22.93),
+                        air_util_tx: Some(2.791),
+                        uptime_seconds: Some(14655892),
+                    }),
+                    channel: 1,
+                    via_mqtt: true,
+                    hops_away: Some(1),
+                    ..Default::default()
+                },
+            )),
+        };
+        let encoded_outer = format_data_packet(outer_packet.encode_to_vec().into()).unwrap();
+        assert!(
+            encoded_outer.data_vec().windows(2).any(|w| w == [0x94, 0xc3]),
+            "outer_packet no longer reproduces the coincidental header collision"
+        );
+
+        let recovery_packet = protobufs::FromRadio {
+            id: 0,
+            payload_variant: Some(protobufs::from_radio::PayloadVariant::NodeInfo(
+                protobufs::NodeInfo {
+                    num: 987654321,
+                    user: Some(protobufs::User {
+                        id: "!cafef00d".to_string(),
+                        long_name: "Recovery Node".to_string(),
+                        short_name: "RCVR".to_string(),
+                        hw_model: protobufs::HardwareModel::HeltecV3 as i32,
+                        public_key: vec![0xcd; 32],
+                        ..Default::default()
+                    }),
+                    channel: 1,
+                    via_mqtt: false,
+                    hops_away: Some(2),
+                    ..Default::default()
+                },
+            )),
+        };
+        let encoded_recovery = format_data_packet(recovery_packet.encode_to_vec().into()).unwrap();
+
+        let (mock_tx, mut mock_rx) = unbounded_channel::<protobufs::FromRadio>();
+        let mut buffer = StreamBuffer::new(mock_tx);
+
+        let mut data = encoded_outer.data_vec();
+        data.extend_from_slice(encoded_recovery.data());
+        buffer.process_incoming_bytes(data.into());
+
+        assert_eq!(timeout_test(mock_rx.recv(), None).await, Some(outer_packet));
+        assert_eq!(
+            timeout_test(mock_rx.recv(), None).await,
+            Some(recovery_packet)
+        );
     }
 
     #[tokio::test]

--- a/src/connections/stream_buffer.rs
+++ b/src/connections/stream_buffer.rs
@@ -37,21 +37,11 @@ pub enum StreamBufferError {
     MissingLSB { lsb_index: usize },
     #[error("Detected malformed packet, packet buffer contains a framing byte at index {next_packet_start_idx}")]
     MalformedPacket { next_packet_start_idx: usize },
-    #[error(
-        "Declared packet size of {declared_size} bytes exceeds max packet size of {max_size} bytes"
-    )]
-    ImplausiblePacketSize {
-        declared_size: usize,
-        max_size: usize,
-    },
     #[error(transparent)]
     DecodeFailure(#[from] prost::DecodeError),
 }
 
 const PACKET_HEADER_SIZE: usize = 4;
-
-// Matches firmware's MAX_TO_FROM_RADIO_SIZE (src/mesh/PhoneAPI.h).
-const MAX_TO_FROM_RADIO_SIZE: usize = 512;
 
 impl StreamBuffer {
     /// Creates a new StreamBuffer instance that will send decoded FromRadio packets
@@ -132,18 +122,6 @@ impl StreamBuffer {
                           );
 
                         continue; // Don't need more data to continue, purge from buffer
-                    }
-                    StreamBufferError::ImplausiblePacketSize {
-                        declared_size,
-                        max_size,
-                    } => {
-                        error!(
-                            "Header declares implausible packet size {declared_size} (max {max_size}), discarding false header"
-                        );
-
-                        self.buffer
-                            .drain(0..PACKET_HEADER_SIZE.min(self.buffer.len()));
-                        continue; // Don't need more data to continue, purge false header
                     }
                     StreamBufferError::DecodeFailure { .. } => {
                         error!("Failed to decode chunk from packet, this does not affect the next iteration");
@@ -307,13 +285,6 @@ impl StreamBuffer {
         // Combine MSB and LSB of incoming packet size bytes
         // Recall that packet size doesn't include the first four magic bytes
         let incoming_packet_data_size: usize = usize::from(u16::from_le_bytes([*lsb, *msb]));
-
-        if incoming_packet_data_size > MAX_TO_FROM_RADIO_SIZE {
-            return Err(StreamBufferError::ImplausiblePacketSize {
-                declared_size: incoming_packet_data_size,
-                max_size: MAX_TO_FROM_RADIO_SIZE,
-            });
-        }
 
         Ok(incoming_packet_data_size)
     }
@@ -754,49 +725,9 @@ mod tests {
     #[tokio::test]
     async fn detect_malformed_packets_with_internal_header_sequence() {}
 
-    /// Test for a [0x94, 0xc3] sequence occurring by chance inside another packet's
-    /// payload. Expected behavior is that the bogus size is rejected and the buffer
-    /// resyncs on the next real packet.
-    #[tokio::test]
-    async fn resync_after_false_header_match_with_implausible_size() {
-        // Arrange
-
-        let payload_variant_1 =
-            protobufs::from_radio::PayloadVariant::MyInfo(protobufs::MyNodeInfo::default());
-        let payload_variant_2 =
-            protobufs::from_radio::PayloadVariant::MyInfo(protobufs::MyNodeInfo::default());
-
-        let (packet_1, packet_data_1) = mock_encoded_from_radio_packet(payload_variant_1, None);
-        let (packet_2, packet_data_2) = mock_encoded_from_radio_packet(payload_variant_2, None);
-
-        let encoded_packet_1 = format_data_packet(packet_data_1.into()).unwrap();
-        let encoded_packet_2 = format_data_packet(packet_data_2.into()).unwrap();
-
-        // Header with a declared size (big-endian MSB/LSB) larger than MAX_TO_FROM_RADIO_SIZE.
-        let false_header = vec![0x94, 0xc3, 254, 6];
-
-        let (mock_tx, mut mock_rx) = unbounded_channel::<protobufs::FromRadio>();
-
-        // Act
-
-        let mut buffer = StreamBuffer::new(mock_tx);
-
-        let mut data = Vec::new();
-        data.extend_from_slice(encoded_packet_1.data());
-        data.extend_from_slice(&false_header);
-        data.extend_from_slice(encoded_packet_2.data());
-        buffer.process_incoming_bytes(data.into());
-
-        // Assert
-
-        assert_eq!(timeout_test(mock_rx.recv(), None).await, Some(packet_1));
-        assert_eq!(timeout_test(mock_rx.recv(), None).await, Some(packet_2));
-        assert_eq!(buffer.buffer.len(), 0);
-    }
-
     /// `outer_packet`'s serialized bytes coincidentally contain [0x94, 0xc3],
-    /// the same collision that caused a real hang before MAX_TO_FROM_RADIO_SIZE
-    /// was added. Identity fields are placeholders; device_metrics is unchanged
+    /// the same collision that caused a real hang. Identity fields are
+    /// placeholders; device_metrics is unchanged
     /// since that's what produces the collision. Expected behavior is that both
     /// packets decode, since the coincidental match doesn't mean outer_packet
     /// is malformed.

--- a/src/connections/stream_buffer.rs
+++ b/src/connections/stream_buffer.rs
@@ -758,17 +758,6 @@ mod tests {
             payload_variant: Some(protobufs::from_radio::PayloadVariant::NodeInfo(
                 protobufs::NodeInfo {
                     num: 987654321,
-                    user: Some(protobufs::User {
-                        id: "!cafef00d".to_string(),
-                        long_name: "Recovery Node".to_string(),
-                        short_name: "RCVR".to_string(),
-                        hw_model: protobufs::HardwareModel::HeltecV3 as i32,
-                        public_key: vec![0xcd; 32],
-                        ..Default::default()
-                    }),
-                    channel: 1,
-                    via_mqtt: false,
-                    hops_away: Some(2),
                     ..Default::default()
                 },
             )),

--- a/src/connections/stream_buffer.rs
+++ b/src/connections/stream_buffer.rs
@@ -324,9 +324,10 @@ impl StreamBuffer {
 
         if let Some(next_packet_start_idx) = next_packet_start_index {
             // Only malformed if it doesn't decode at the declared length.
-            let declared_packet =
+            let mut declared_packet =
                 &self.buffer[packet_data_start_index..packet_data_start_index + packet_data_size];
-            if protobufs::FromRadio::decode(declared_packet).is_ok() {
+            if protobufs::FromRadio::decode(&mut declared_packet).is_ok()
+                && declared_packet.is_empty()
                 return Ok(());
             }
 

--- a/src/connections/stream_buffer.rs
+++ b/src/connections/stream_buffer.rs
@@ -734,31 +734,16 @@ mod tests {
     #[tokio::test]
     async fn resync_after_coincidental_header_match_inside_packet_payload() {
         let outer_packet = protobufs::FromRadio {
-            id: 0,
             payload_variant: Some(protobufs::from_radio::PayloadVariant::NodeInfo(
                 protobufs::NodeInfo {
-                    num: 1234567890,
-                    user: Some(protobufs::User {
-                        id: "!deadbeef".to_string(),
-                        long_name: "Test Node".to_string(),
-                        short_name: "TEST".to_string(),
-                        hw_model: protobufs::HardwareModel::HeltecV3 as i32,
-                        public_key: vec![0xab; 32],
+                    device_metrics: Some(protobufs::DeviceMetrics {
+                        uptime_seconds: Some(14655892),
                         ..Default::default()
                     }),
-                    device_metrics: Some(protobufs::DeviceMetrics {
-                        battery_level: Some(100),
-                        voltage: Some(4.219),
-                        channel_utilization: Some(22.93),
-                        air_util_tx: Some(2.791),
-                        uptime_seconds: Some(14655892),
-                    }),
-                    channel: 1,
-                    via_mqtt: true,
-                    hops_away: Some(1),
                     ..Default::default()
                 },
             )),
+            ..Default::default()
         };
         let encoded_outer = format_data_packet(outer_packet.encode_to_vec().into()).unwrap();
         assert!(

--- a/src/connections/stream_buffer.rs
+++ b/src/connections/stream_buffer.rs
@@ -328,6 +328,7 @@ impl StreamBuffer {
                 &self.buffer[packet_data_start_index..packet_data_start_index + packet_data_size];
             if protobufs::FromRadio::decode(&mut declared_packet).is_ok()
                 && declared_packet.is_empty()
+            {
                 return Ok(());
             }
 


### PR DESCRIPTION
**Summary**
Fixes a very rare situation where the stream parser can start attempting to parse a legitimate packet's bytes as a new frame/packet when that packet contains the Meshtastic protocol magic bytes, and then the parser just starts eating all incoming bytes as part of that frame, and never completing the packet emission. This completely halts the stream.

**Proposed Changes**
-  ~The approach in this PR recognizes strange packet sizes and is like "no way."~ 
- Attempt to decode a supposedly malformed packet before actually deciding it is malformed.

**Checklist**
- [ ] Tests pass locally
- [ ] Documentation updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved packet validation when payload data contains byte sequences resembling malformed packet markers.
  * Valid packets now decode correctly when these sequences appear within their payload.
  * Connection streams continue processing subsequent packets after misleading marker data is encountered.
  * Added regression coverage for affected packets and following recovery packets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->